### PR TITLE
quick fix for example_lib_exec

### DIFF
--- a/examples/example_lib_exec.ks
+++ b/examples/example_lib_exec.ks
@@ -1,6 +1,6 @@
 // This file is distributed under the terms of the MIT license, (c) the KSLib team
 
-run exec_lib.
+run lib_exec.
 
 execute("set " + "x" + " to " + "42" + "." + "print x."). // set x to 42. print x.
 


### PR DESCRIPTION
I forgot to edit the example when I renamed exec_lib to lib_exec