### PR TITLE
Changed return value wait for actio group

### DIFF
--- a/doc/lib_raw_user_input.md
+++ b/doc/lib_raw_user_input.md
@@ -14,7 +14,7 @@ args:
   * ag_list - list of strings, a list of action group names to listen.
 
 returns:
-  * string, a name of action group activated by user
+  * number, an index of action group activated by user in ag_list.
 
 description:
   * Wait until user activates one of the action groups from ag_list,

--- a/examples/example_lib_raw_user_input.ks
+++ b/examples/example_lib_raw_user_input.ks
@@ -8,11 +8,11 @@ until quit
   print "1. submenu".
   print "2. quit".
   local menu_option is wait_for_action_groups(list("ag1", "ag2")).
-  if menu_option = "ag2"
+  if menu_option = 1
   {
     set quit to true.
   }
-  else if menu_option = "ag1"
+  else if menu_option = 0
   {
     local sub_quit is false.
     until sub_quit
@@ -22,12 +22,12 @@ until quit
       print "1. say hello".
       print "2. main menu".
       local menu_option is wait_for_action_groups(list("ag1", "ag2")).
-      if menu_option = "ag1"
+      if menu_option = 0
       {
         print "hello".
         wait 1.
       }
-      else if menu_option = "ag2"
+      else if menu_option = 1
       {
         set sub_quit to true.
       }

--- a/library/lib_raw_user_input.ks
+++ b/library/lib_raw_user_input.ks
@@ -33,5 +33,5 @@ function wait_for_action_groups
   execute("run " + tmp_file_name + ".").
   wait until _wait_for_ag__ag_index <> -1.
   delete tmp_file_name.
-  return ag_list[_wait_for_ag__ag_index].
+  return _wait_for_ag__ag_index.
 }


### PR DESCRIPTION
Reasons:
1) I'd like to be more consistent and interchangeable with future
version that will be based  on the "proper" user input (when such a
feature gets implemented).
2) Integer as a return value is slightly more useful: it can be used as
an array index.