### PR TITLE
Fixes #86

### DIFF
--- a/doc/lib_lazcalc.md
+++ b/doc/lib_lazcalc.md
@@ -8,12 +8,12 @@ inclination and can continued to be used throughout accent to update the heading
 ## LAZcalc_init()
 
 args:
-  * Desired circular target orbit altitude *in kilometers*.
+  * Desired circular target orbit altitude *in meters*. **Note:** Versions 2.0 and prior had the input altitude in kilometers
   * Desired target orbit inclination. Input a negative number if you want to launch from the descendingnode (a launch like this would take you on a heading *south* of 90 degrees)
 **Note:** If the inclination input is impossible to reach from the ship's current latitude, the script will attempt to determine whether the user is seeking an easterly or westerly launch and then will correct the input inclination to allow for the lowest (easterly) or highest (westerly) inclination possible.
 
 returns:
-  * A a list.
+  * A list.
 
 description:
   * Returns a list to be used by the `LAZcalc` function containing all the relevant calcualtions that can or need to be performed from the launch site.

--- a/examples/example_lib_lazcalc.ks
+++ b/examples/example_lib_lazcalc.ks
@@ -10,39 +10,39 @@ LOCAL launchAzimuth TO 0.
 
 PRINT "Target Alt | Target Inc | Node    | Launch Azimuth".
 PRINT "--------------------------------------------------".
-SET struct to LAZcalc_init(130,0).
+SET struct to LAZcalc_init(130000,0).
 SET launchAzimuth TO LAZcalc(struct).
 PRINT "  130km    |  0deg      | Asc     | " +  ROUND(launchAzimuth,2) + "deg".
 PRINT "--------------------------------------------------".
-SET struct to LAZcalc_init(450,51.6).
+SET struct to LAZcalc_init(450000,51.6).
 SET launchAzimuth TO LAZcalc(struct).
 PRINT "  450km    |  51.6deg   | Asc     | " +  ROUND(launchAzimuth,2) + "deg".
 PRINT "--------------------------------------------------".
-SET struct to LAZcalc_init(120,40).
+SET struct to LAZcalc_init(120000,40).
 SET launchAzimuth TO LAZcalc(struct).
 PRINT "  120km    |  40deg     | Asc     | " +  ROUND(launchAzimuth,2) + "deg".
 PRINT "--------------------------------------------------".
-SET struct to LAZcalc_init(500,-60).
+SET struct to LAZcalc_init(500000,-60).
 SET launchAzimuth TO LAZcalc(struct).
 PRINT "  500km    |  60deg     | Dec     | " +  ROUND(launchAzimuth,2) + "deg".
 PRINT "--------------------------------------------------".
-SET struct to LAZcalc_init(130,-180).
+SET struct to LAZcalc_init(130000,-180).
 SET launchAzimuth TO LAZcalc(struct).
 PRINT "  130km    |  180deg    | Dec     | " +  ROUND(launchAzimuth,2) + "deg".
 PRINT "--------------------------------------------------".
-SET struct to LAZcalc_init(250,120).
+SET struct to LAZcalc_init(250000,120).
 SET launchAzimuth TO LAZcalc(struct).
 PRINT "  250km    |  120deg    | Asc     | " +  ROUND(launchAzimuth,2) + "deg".
 PRINT "--------------------------------------------------".
-SET struct to LAZcalc_init(150,-90).
+SET struct to LAZcalc_init(150000,-90).
 SET launchAzimuth TO LAZcalc(struct).
 PRINT "  150km    |  90deg     | Dec     | " +  ROUND(launchAzimuth,2) + "deg".
 PRINT "--------------------------------------------------".
-SET struct to LAZcalc_init(250,90).
+SET struct to LAZcalc_init(250000,90).
 SET launchAzimuth TO LAZcalc(struct).
 PRINT "  250km    |  90deg     | Asc     | " +  ROUND(launchAzimuth,2) + "deg".
 PRINT "--------------------------------------------------".
-SET struct to LAZcalc_init(1000,-105).
+SET struct to LAZcalc_init(1000000,-105).
 SET launchAzimuth TO LAZcalc(struct).
 PRINT "  1000km   |  105deg    | Dec     | " +  ROUND(launchAzimuth,2) + "deg".
 PRINT "--------------------------------------------------".

--- a/library/lib_lazcalc.ks
+++ b/library/lib_lazcalc.ks
@@ -1,63 +1,83 @@
 //This file is distributed under the terms of the MIT license, (c) the KSLib team
 //=====LAUNCH AZIMUTH CALCULATOR=====
 //~~LIB_LAZcalc.ks~~
-//~~Version 2.0~~
+//~~Version 2.1~~
 //~~Created by space-is-hard~~
 //~~Updated by TDW89~~
 
-//To use: RUN LAZcalc.ks. SET data TO LAZcalc_init([desired circular orbit altitude in kilometers],[desired orbital inclination; negative if launching from descending node, positive otherwise]). Then loop SET myAzimuth TO LAZcalc(data).
+//To use: RUN LAZcalc.ks. SET data TO LAZcalc_init([desired circular orbit altitude in meters],[desired orbital inclination; negative if launching from descending node, positive otherwise]). Then loop SET myAzimuth TO LAZcalc(data).
 
 @LAZYGLOBAL OFF.
 
 FUNCTION LAZcalc_init {
- PARAMETER
-  desiredAlt, //Altitude of desired target orbit (in kilometers)
-  desiredInc. //Inclination of desired target orbit
-  
- LOCAL data IS LIST().   // A list is used to store information used by LAZcalc
-
- //#open Input Sterilization
- 
- //Converts kilometers to meters (coment out to input in meters).
- set desiredAlt to desiredAlt*1000.
- 
- //Orbital altitude can't be less than sea level
- IF desiredAlt <= 0 {
-	PRINT "Target altitude cannot be below sea level".
-	SET launchAzimuth TO 1/0.		//Throws error
- }.
-
- //Orbital inclination can't be less than launch latitude or greater than 180 - launch latitude
- if abs(ship:geoposition:lat) > abs(desiredInc) {
-  set inc to abs(ship:geoposition:lat).
-  HUDTEXT("Inclination impossible from current latitude, setting for closest possible inclination.", 10, 2, 30, RED, FALSE).
- }.
- if 180-abs(ship:geoposition:lat) < abs(desiredInc) {
-  set desiredInc to 180-abs(ship:geoposition:lat).
-  HUDTEXT("Inclination impossible from current latitude, setting for closest possible inclination.", 10, 2, 30, RED, FALSE).
- }.
- 
- //#close Input Sterilization
- 
- //Does all the one time calculations and stores them in a list to help reduce the overhead or continuously updating
- LOCAL launchLatitude IS SHIP:LATITUDE.
- LOCAL equatorialVel IS (2 * CONSTANT():Pi * BODY:RADIUS) / BODY:ROTATIONPERIOD.
- LOCAL targetOrbVel IS SQRT(BODY:MU/ (BODY:RADIUS + desiredAlt)).
- data:ADD(desiredInc).     //[0]
- data:ADD(launchLatitude). //[1]
- data:ADD(equatorialVel).  //[2]
- data:ADD(targetOrbVel).   //[3]
- RETURN data.
+    PARAMETER
+        desiredAlt, //Altitude of desired target orbit (in *meters*)
+        desiredInc. //Inclination of desired target orbit
+    
+    //We'll pull the latitude now so we aren't sampling it multiple times
+    LOCAL launchLatitude IS SHIP:LATITUDE.
+    
+    LOCAL data IS LIST().   // A list is used to store information used by LAZcalc
+    
+    //Orbital altitude can't be less than sea level
+    IF desiredAlt <= 0 {
+        PRINT "Target altitude cannot be below sea level".
+        SET launchAzimuth TO 1/0.		//Throws error
+    }.
+    
+    //Determines whether we're trying to launch from the ascending or descending node
+    LOCAL launchNode TO "Ascending".
+    IF desiredInc < 0 {
+        SET launchNode TO "Descending".
+        
+        //We'll make it positive for now and convert to southerly heading later
+        SET desiredInc TO ABS(desiredInc).
+    }.
+    
+    //Orbital inclination can't be less than launch latitude or greater than 180 - launch latitude
+    IF ABS(launchLatitude) > desiredInc {
+        SET desiredInc TO ABS(launchLatitude).
+        HUDTEXT("Inclination impossible from current latitude, setting for lowest possible inclination.", 10, 2, 30, RED, FALSE).
+    }.
+    
+    IF 180 - ABS(launchLatitude) < desiredInc {
+        SET desiredInc TO 180 - ABS(launchLatitude).
+        HUDTEXT("Inclination impossible from current latitude, setting for highest possible inclination.", 10, 2, 30, RED, FALSE).
+    }.
+    
+    //Does all the one time calculations and stores them in a list to help reduce the overhead or continuously updating
+    LOCAL equatorialVel IS (2 * CONSTANT():Pi * BODY:RADIUS) / BODY:ROTATIONPERIOD.
+    LOCAL targetOrbVel IS SQRT(BODY:MU/ (BODY:RADIUS + desiredAlt)).
+    data:ADD(desiredInc).       //[0]
+    data:ADD(launchLatitude).   //[1]
+    data:ADD(equatorialVel).    //[2]
+    data:ADD(targetOrbVel).     //[3]
+    data:ADD(launchNode).       //[4]
+    RETURN data.
 }.
 
-function LAZcalc {
- PARAMETER
-  data. //pointer to the list created by LAZcalc_init
- LOCAL inertialAzimuth IS ARCSIN(max(min(COS(data[0])/COS(SHIP:LATITUDE),1),-1)).
- LOCAL VXRot IS data[3]*SIN(inertialAzimuth)-data[2]*COS(data[1]).
- LOCAL VYRot IS data[3]*COS(inertialAzimuth).
- LOCAL Azimuth IS ARCTAN2(VXRot,VYRot).
-
- // This clamps the result to values between 0 and 360.
- RETURN MOD(Azimuth+360,360).
+FUNCTION LAZcalc {
+    PARAMETER
+        data. //pointer to the list created by LAZcalc_init
+    LOCAL inertialAzimuth IS ARCSIN(MAX(MIN(COS(data[0]) / COS(SHIP:LATITUDE), 1), -1)).
+    LOCAL VXRot IS data[3] * SIN(inertialAzimuth) - data[2] * COS(data[1]).
+    LOCAL VYRot IS data[3] * COS(inertialAzimuth).
+    
+    // This clamps the result to values between 0 and 360.
+    LOCAL Azimuth IS MOD(ARCTAN2(VXRot, VYRot) + 360, 360).
+    
+    //Returns northerly azimuth if launching from the ascending node
+    IF data[4] = "Ascending" {
+        RETURN Azimuth.
+        
+    //Returns southerly azimuth if launching from the descending node
+    } ELSE IF data[4] = "Descending" {
+        IF Azimuth <= 90 {
+            RETURN 180 - Azimuth.
+            
+        } ELSE IF Azimuth >= 270 {
+            RETURN 540 - Azimuth.
+            
+        }.
+    }.
 }.


### PR DESCRIPTION
Also includes formatting changes (the single-space indents and mixed uppercase and lowercase keywords were making me twitch).

**ALSO** Changes input altitude from being in kilometers to just meters. When lazcalc was created, functions did not yet exist. The intended use was to supplement manual flying, where the user was to run the script from the terminal and it would tell them what direction to launch towards. This meant that it was easier to just punch in `run lazcalc(200, 53.6)` and fly it as best as you could. Having to worry about if you got the number of digits correct wasn't what I wanted, as you most likely weren't going to be that accurate with manual flying anyways.

But lazcalc has evolved into a tool that fully-automatic launcher scripts can use to precisely nail a specified inclination, and those scripts tend to work in the native unit of meters for accuracy purposes. I figure that now we can make it easier on the script makers, and if they want to make it easy for the user by letting them input the target altitude in kilometers, it can be on them to convert to meters before passing the value to lazcalc.

##Todo:
- [x] Update documentation (note km -> meters change)
- [x] Update example (change km input to meters)
- [x] Testing
