### PR TITLE
Fixes #89

### DIFF
--- a/library/lib_navball.ks
+++ b/library/lib_navball.ks
@@ -36,15 +36,19 @@ function pitch_for {
 
 function roll_for {
   parameter ves.
-
-  local raw is vang(ves:up:vector, ves:facing:starvector).
-  if vang(ves:up:vector, ves:facing:topvector) > 90 {
-    if raw > 90 {
-      return 270 - raw.
-    } else {
-      return -90 - raw.
-    }
+  
+  if vang(ship:facing:vector,ship:up:vector) < 0.2 { //this is the dead zone for roll when the ship is vertical
+    return 0.
   } else {
-    return raw - 90.
-  }
+    local raw is vang(vxcl(ship:facing:vector,ship:up:vector), ves:facing:starvector).
+    if vang(ves:up:vector, ves:facing:topvector) > 90 {
+      if raw > 90 {
+        return 270 - raw.
+      } else {
+        return -90 - raw.
+      }
+    } else {
+      return raw - 90.
+    }
+  } 
 }.


### PR DESCRIPTION
Fixes the issue with roll_for calculating the roll from the up vector without taking pitch into account.
potential changes for the future:
 - compass for could be changed to use `-ship:facing:topvector` when it is near vertical
 - pitch_for could be changed to go so that it gave a pitch of 100 when the vessel was inverted 10 degrees from up (currently gives 80.