### PR TITLE
Add lib_get_type variable type inference

### DIFF
--- a/doc/lib_get_type.md
+++ b/doc/lib_get_type.md
@@ -1,0 +1,18 @@
+// This file is distributed under the terms of the MIT license, (c) the KSLib team
+
+##lib_get_type
+
+``lib_get_type.ks`` can be used to infer the type of a variable,
+differentiating between strings, numbers, lists, lexicons, stacks, queues, and
+other kOS structs.
+
+### get_type
+
+args:
+  * The variable whose type you want to infer, of any type.
+
+returns:
+  * string
+
+description:
+  * This is mainly intended to help make other functions more generalized, by allowing them to operate intuitively on single items, or collections of items. You can now design functions that call `get_type()` on their arguments, to determine how they should respond. You can also use `get_type()` to check the types of your arguments, allowing functions to return back an error message, rather than crashing the program.

--- a/examples/example_lib_get_type.ks
+++ b/examples/example_lib_get_type.ks
@@ -1,0 +1,23 @@
+// This file is distributed under the terms of the MIT license, (c) the KSLib team
+
+run lib_get_type.
+
+function print_many_messages {
+  parameter messages.
+
+  if get_type(messages) = "STRING" {
+    print messages.
+  } else {
+    for message in messages {
+      print message.
+    }
+  }
+}
+
+print_many_messages("Howdy").
+
+print_many_messages(list(
+  "Isn't it cool how we can now",
+  "have a single function run on",
+  "both a list and a single string?"
+)).

--- a/library/lib_get_type.ks
+++ b/library/lib_get_type.ks
@@ -1,0 +1,21 @@
+// This file is distributed under the terms of the MIT license, (c) the KSLib team
+
+@LAZYGLOBAL off.
+
+local complexTypes is list("LEXICON","QUEUE","STACK","LIST","SHIP","VECTOR","DIRECTION","GEOCOORDINATES","ORBIT","ORBITABLE","ORBITALVELOCITY","BODY","ATMOSPHERE","CONTROL","MANEUVERNODE","ENGINE","AGGREGATERESOURCE","DOCKINGPORT","STAGE","PART","PARTMODULE","SENSOR","VESSELSENSORS","LOADDISTANCE","CONFIG","FILEINFO","HIGHLIGHT","ITERATOR","KUNIVERSE","TERMINAL","CORE","PIDLOOP","STEERINGMANAGER").
+
+function get_type {
+  parameter input.
+
+  // Putting the input in a lexicon lets us get a description of its type,
+  // unless it's a string or number.
+  local l is lexicon().
+  set l[0] to input.
+  local complexType is l:dump:split(" ")[6]:split("(")[0]. ")".
+
+  if complexTypes:contains(complexType) return complexType.
+
+  // Determine string or num: 5+0+""="5"; "5"+0+"" = "50"
+  if (input+""):LENGTH = (input+0+""):LENGTH return "NUMBER".
+  return "STRING".
+}


### PR DESCRIPTION
Another fun library, variable type inference!

```
get_type(5) => "NUMBER"
get_type("5") => "STRING"
get_type(list()) => "LIST"
get_type(vessel("targetVessel")) => "SHIP"
... etc
```

Useful for type-checking in other functions in order to fail gently when passed invalid arguments, or to allow functions to operate on both collections and single items.