### PR TITLE
Fix lib_enum docs, and use lex()

### DIFF
--- a/doc/lib_enum.md
+++ b/doc/lib_enum.md
@@ -78,7 +78,7 @@ Calls the match_fn with each element in the collection, and returns the number o
 Example:
 ```
 function is_even { parameter n. return mod(n,2) = 0. }
-Enum_count(queue(1,2,3,4,5), is_even@). // 2
+Enum["count"](queue(1,2,3,4,5), is_even@). // 2
 ```
 
 ### Enum["each"]
@@ -147,7 +147,7 @@ Returns the first element in the collection for which match_fn returns `true`.
 Example:
 ```
 function is_even { parameter n. return mod(n,2) = 0. }
-Enum_find(list(1,2,3,4,5), is_even@). // 2
+Enum["find"](list(1,2,3,4,5), is_even@). // 2
 ```
 
 ### Enum["find_index"]
@@ -164,7 +164,7 @@ Returns the index of the first element in the collection for which match_fn retu
 Example:
 ```
 function is_even { parameter n. return mod(n,2) = 0. }
-Enum_find_index(list(1,2,3,4,5), is_even@). // 1
+Enum["find_index"](list(1,2,3,4,5), is_even@). // 1
 ```
 
 ### Enum["group_by"]

--- a/library/lib_enum.ks
+++ b/library/lib_enum.ks
@@ -1,7 +1,7 @@
 // This file is distributed under the terms of the MIT license, (c) the KSLib
 // team
 
-{global Enum is lexicon(
+{global Enum is lex(
 "version", "0.1.1",
 "all", all@,
 "any", any@,
@@ -61,7 +61,7 @@ function find_index{
   parameter l,c,i is 0. for j in to_l(l) {if c(j) return i. set i to i+1.}
   return -1.}
 
-function group_by{parameter l,t,r is lexicon(). for i in l{
+function group_by{parameter l,t,r is lex(). for i in l{
   local u is t(i). if r:haskey(u) r[u]:add(i). else set r[u] to list(i).}
   for k in r:keys set r[k] to cast(r[k],l:typename). return r.}
 


### PR DESCRIPTION
Had some incorrect usage examples for lib_enum, and swapped `lexicon()` for `lex()` to save a few characters.