### PR TITLE
Doc fixes

### DIFF
--- a/doc/lib_gui_box.md
+++ b/doc/lib_gui_box.md
@@ -11,8 +11,8 @@ This library contains functions to draw boxes like this:
 ```
 in the terminal.
 
-dependencies:
-  * spec_char.ksm
+Dependencies:
+  * [spec_char.ksm](https://github.com/KSP-KOS/KSLib/blob/master/library_ksm/spec_char.ksm)
 
 ### draw_gui_box
 

--- a/doc/lib_gui_box.md
+++ b/doc/lib_gui_box.md
@@ -11,6 +11,9 @@ This library contains functions to draw boxes like this:
 ```
 in the terminal.
 
+dependencies:
+  * spec_char.ksm
+
 ### draw_gui_box
 
 args:

--- a/doc/lib_input_string.md
+++ b/doc/lib_input_string.md
@@ -5,6 +5,11 @@
 ``lib_input_string.ks`` provides a method of inputting custom strings while a script is running via an on-screen keyboard.
 
 
+dependencies:
+  * lib_file_exists.ks
+  * spec_char.ksm
+
+
 ###input_string
 
 args:

--- a/doc/lib_input_string.md
+++ b/doc/lib_input_string.md
@@ -5,9 +5,9 @@
 ``lib_input_string.ks`` provides a method of inputting custom strings while a script is running via an on-screen keyboard.
 
 
-dependencies:
-  * lib_file_exists.ks
-  * spec_char.ksm
+Dependencies:
+  * [lib_file_exists.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_file_exists.ks)
+  * [spec_char.ksm](https://github.com/KSP-KOS/KSLib/blob/master/library_ksm/spec_char.ksm)
 
 
 ###input_string

--- a/doc/lib_list_dialog.md
+++ b/doc/lib_list_dialog.md
@@ -4,8 +4,8 @@
 
 This library helps when you want the user to choose a value from a long list.
 
-dependencies:
-  * lib_menu
+Dependencies:
+  * [lib_menu.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_menu.ks)
 
 ### open_list_dialog
 

--- a/doc/lib_menu.md
+++ b/doc/lib_menu.md
@@ -4,8 +4,8 @@
 
 Use this library when you want to display a menu on the screen.
 
-dependencies:
-  * lib_gui_box
+Dependencies:
+  * [lib_gui_box.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_gui_box.ks)
 
 ### open_menu
 

--- a/doc/lib_menu.md
+++ b/doc/lib_menu.md
@@ -4,6 +4,9 @@
 
 Use this library when you want to display a menu on the screen.
 
+dependencies:
+  * lib_gui_box
+
 ### open_menu
 
 args:

--- a/doc/lib_number_dialog.md
+++ b/doc/lib_number_dialog.md
@@ -4,8 +4,8 @@
 
 A dialog where the user can enter any number (including negative and fractional).
 
-dependencies:
-  * lib_gui_box
+Dependencies:
+  * [lib_gui_box.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_gui_box.ks)
 
 ### open_number_dialog
 

--- a/doc/lib_number_dialog.md
+++ b/doc/lib_number_dialog.md
@@ -4,6 +4,9 @@
 
 A dialog where the user can enter any number (including negative and fractional).
 
+dependencies:
+  * lib_gui_box
+
 ### open_number_dialog
 
 args:

--- a/doc/lib_raw_user_input.md
+++ b/doc/lib_raw_user_input.md
@@ -5,8 +5,8 @@
 A low level library to do user input via action groups.
 I believe it supports AGX to.
 
-dependencies:
-  * lib_exec library
+Dependencies:
+  * [lib_exec.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_exec.ks)
 
 ### wait_for_action_groups
 


### PR DESCRIPTION
Adds missing dependencies to documentation for 2 libraries.
Changes dependency info to also link to the relevant library.
While any library using `lib_has_exists.ks` and `spec_char.ksm` should be changed to not require them at present they do and so the documentation should reflect that.