### PR TITLE
Lib raw user input fix

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,7 +5,7 @@ This is an attempt at summarising and categorising the libraries by their use ca
 
 ### Control
 1. [lib_pid.ks](https://github.com/KSP-KOS/KSLib/master/library/lib_pid.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_pid.md) : provides functions for creating a PID controller. This functionality has been superseded by kOS buil-in `PIDLoop()`.
-2. [lib_raw_user_input.ks](https://github.com/KSP-KOS/KSLib/master/library/lib_raw_user_input.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_raw_user_input.md) : currently broken. Listens for action groups in a list and returns the index of the activated action group.
+2. [lib_raw_user_input.ks](https://github.com/KSP-KOS/KSLib/master/library/lib_raw_user_input.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_raw_user_input.md) : Listens for action groups in a list and returns the index of the activated action group.
 
 ### Data Structures
 1. [lib_enum.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_enum.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_enum.md) : provides functions to manipulate structures like lists, stacks, queues etc.

--- a/doc/lib_num_to_formatted_str.md
+++ b/doc/lib_num_to_formatted_str.md
@@ -79,7 +79,8 @@ This function will return a time string formatted according to the following rul
   * Converts number of seconds into one of seven different time formats
   * Will detect if you are using the 6 hour KSP day or the 24 hour Earth day and change the day and year to match
     * For ease of calculation this function defines 1 year as 426 Kerbin days or 365 Earth days.
-    * NOTE: you will need to keep the return the same format or else you will break other functions
+      * If you with to change this consider modifying `FUNCTION time_converter`
+      * NOTE: you will need to keep the return the same format or else you will break other functions
 
 | parameter    | type    | default    | description                                                                     |
 |--------------|---------|------------|---------------------------------------------------------------------------------|

--- a/library/lib_raw_user_input.ks
+++ b/library/lib_raw_user_input.ks
@@ -24,7 +24,7 @@ function wait_for_action_groups
       }
     }
     local result is iter_a:index.
-    if iter_a:atend and iter_b:atend
+    if iter_a:atend or iter_b:atend
     {
       set result to -1.
     }
@@ -48,6 +48,7 @@ function wait_for_action_groups
   until result <> -1
   {
     set result to first_diff(old_values, _raw_input_ag_list).
+	wait 0.
   }
 
   return result.

--- a/library/lib_raw_user_input.ks
+++ b/library/lib_raw_user_input.ks
@@ -48,7 +48,7 @@ function wait_for_action_groups
   until result <> -1
   {
     set result to first_diff(old_values, _raw_input_ag_list).
-	wait 0.
+    wait 0.
   }
 
   return result.


### PR DESCRIPTION
fixes bug in `lib_raw_user_input.ks`
Interestingly this bug was ether always in the lib once it moved away from using a trigger or when the lib was made kOS didn't do short circuiting.