### PR TITLE
Lib exec improvments

### DIFF
--- a/doc/lib_exec.md
+++ b/doc/lib_exec.md
@@ -74,6 +74,25 @@ example:
   `print evaluate_function("foo", list(42, true, "hello")).`
   does exactly the same as:
   `print foo(42, true, "hello").`
+  
+### get_suffix
+
+args:
+  * structure - the structure to get the suffix of
+  * suffix - the suffix to get
+  * parameter_list - if a suffix is a function then this is the ordered list of parameters to be passed to the suffix 0th parameter maps to the 0th item in the list, will be ignored if not of type list, defaulted to `FALSE`
+  
+returns:
+  * result - will be what ever the suffix returns
+  
+exmaple:
+```
+  print get_suffix(ship,"mass").
+  print get_suffix(body,"geopositionlatlng",list(1,2)).```
+  is equivalent to 
+```
+  print ship:mass.
+  print body:geopositionlatlng(1,2).```
 
 ### useful tips
 

--- a/doc/lib_exec.md
+++ b/doc/lib_exec.md
@@ -7,7 +7,7 @@ As far as I know it works fine in all possible special cases.
 
 #### WARNINGS:
   * this library can fail if there is insufficient free space on the local volume.
-  * this library requires several global variables to work as a result any scripts making use of this library should not use to any of the following variable names: `_exec_idString` , `_evaluate_result` , `_exec__param_list` , `_past_exec_strings`
+  * this library requires several global variables to work. As a result, any scripts making use of this library should not use any of the following variable names: `_exec_idString` , `_evaluate_result` , `_exec__param_list` , `_past_exec_strings`
 
 ### execute
 

--- a/doc/lib_exec.md
+++ b/doc/lib_exec.md
@@ -56,7 +56,7 @@ caveat #3
 ### evaluate
 
 args:
-  * expression - an expression to evaluate. Unlike "command" parameter from function
+  * expression - string, an expression to evaluate. Unlike "command" parameter from function
     `execute` an expression should **not** end with dot: `evaluate("7 * a + 2").`.
 
 returns:
@@ -85,9 +85,9 @@ example:
 ### get_suffix
 
 args:
-  * structure - the structure to get the suffix of
-  * suffix - the suffix to get
-  * parameter_list - if a suffix is a function then this is the ordered list of parameters to be passed to the suffix 0th parameter maps to the 0th item in the list, will be ignored if not of type list, defaulted to `FALSE`
+  * structure - any structure, the structure to get the suffix of
+  * suffix - string, the suffix to get
+  * parameter_list - list of anything, if a suffix is a function then this is the ordered list of parameters to be passed to the suffix 0th parameter maps to the 0th item in the list, will be ignored if not of type list, defaulted to `FALSE`
 
 returns:
   * result - will be what ever the suffix returns
@@ -106,9 +106,9 @@ print body:geopositionlatlng(1,2).
 ### set_suffix
 
 args:
-  * structure, the structure to set the suffix of
-  * suffix, the suffix to set
-  * val, the value to set the suffix to
+  * structure - any structure, the structure to set the suffix of
+  * suffix - string, the suffix to set
+  * val - any structure, the value to set the suffix to
 
 example:
   `set_suffix(core,"tag","lib_exec").`

--- a/doc/lib_exec.md
+++ b/doc/lib_exec.md
@@ -85,7 +85,7 @@ args:
 returns:
   * result - will be what ever the suffix returns
   
-exmaple:
+example:
 ```
   print get_suffix(ship,"mass").
   print get_suffix(body,"geopositionlatlng",list(1,2)).```
@@ -93,6 +93,18 @@ exmaple:
 ```
   print ship:mass.
   print body:geopositionlatlng(1,2).```
+  
+### set_suffix
+
+args:
+  * structure, the structure to set the suffix of
+  * suffix, the suffix to set
+  * val, the value to set the suffix to
+  
+example:
+  `set_suffix(core,"tag","lib_exec").`
+  is the same as
+  `set core:tag to "lib_exec".
 
 ### useful tips
 

--- a/doc/lib_exec.md
+++ b/doc/lib_exec.md
@@ -5,6 +5,9 @@
 This library is a powerful tool for unhardcoding program's behavior.
 As far as I know it works fine in all possible special cases.
 
+#### WARNING:
+  * this library can fail if there is insufficient free space on the local volume.
+
 ### execute
 
 args:
@@ -17,7 +20,7 @@ description:
 
 example:
   `execute("set x to 42. print x.").`
-  
+
 caveat #1:
   * run command in the current version of kOS works in a weird way:
 ```
@@ -43,6 +46,9 @@ caveat #2:
   execute("print my_example_var.").
 }
 ```
+
+caveat #3
+  * The limit on the size of a command that can be executed is how much free space you have on the local volume of the core
 
 ##### The same caveats apply to other functions from this library.
 
@@ -74,37 +80,40 @@ example:
   `print evaluate_function("foo", list(42, true, "hello")).`
   does exactly the same as:
   `print foo(42, true, "hello").`
-  
+
 ### get_suffix
 
 args:
   * structure - the structure to get the suffix of
   * suffix - the suffix to get
   * parameter_list - if a suffix is a function then this is the ordered list of parameters to be passed to the suffix 0th parameter maps to the 0th item in the list, will be ignored if not of type list, defaulted to `FALSE`
-  
+
 returns:
   * result - will be what ever the suffix returns
-  
+
 example:
 ```
-  print get_suffix(ship,"mass").
-  print get_suffix(body,"geopositionlatlng",list(1,2)).```
-  is equivalent to 
+print get_suffix(ship,"mass").
+print get_suffix(body,"geopositionlatlng",list(1,2)).
 ```
-  print ship:mass.
-  print body:geopositionlatlng(1,2).```
-  
+  is equivalent to
+```
+print ship:mass.
+print body:geopositionlatlng(1,2).
+```
+
 ### set_suffix
 
 args:
   * structure, the structure to set the suffix of
   * suffix, the suffix to set
   * val, the value to set the suffix to
-  
+
 example:
   `set_suffix(core,"tag","lib_exec").`
   is the same as
   `set core:tag to "lib_exec".
+
 
 ### useful tips
 

--- a/doc/lib_exec.md
+++ b/doc/lib_exec.md
@@ -5,8 +5,9 @@
 This library is a powerful tool for unhardcoding program's behavior.
 As far as I know it works fine in all possible special cases.
 
-#### WARNING:
+#### WARNINGS:
   * this library can fail if there is insufficient free space on the local volume.
+  * this library requires several global variables to work as a result any scripts making use of this library should not use to any of the following variable names: `_exec_idString` , `_evaluate_result` , `_exec__param_list` , `_past_exec_strings`
 
 ### execute
 

--- a/library/lib_exec.ks
+++ b/library/lib_exec.ks
@@ -143,7 +143,7 @@ function set_suffix {
   return result.
 }
 
-local function log_run_del{
+local function log_run_del {
   parameter
     log_string,//the string to be executed
     file_path. //the path to where the string should be stored temporarily so it can be executed.

--- a/library/lib_exec.ks
+++ b/library/lib_exec.ks
@@ -51,12 +51,8 @@ function execute
   }
   if carry { set _exec_idString to char(128) + _exec_idString. }
   //end of string incrementing
-  local filePath IS path("_execute_" + _exec_idString + ".tmp").
-  if exists(filePath) { deletepath(filePath). }
-  log command to filePath.
-  wait 0.
-  runpath(filePath).
-  deletepath(filePath).
+  local filePath IS path("1:/_execute_" + _exec_idString + ".tmp").
+  log_run_del(command,filePath).
 }
 
 function evaluate
@@ -88,4 +84,19 @@ function evaluate_function
   set expression to function_name + "(" + expression + ")".
   unset _exec__param_list.
   return evaluate(expression).
+}
+
+local function log_run_del
+{
+  parameter
+    log_string,//the string to be executed
+    file_path. //the path to where the string should be stored temporarily so it can be executed.
+  if exists(file_path)
+  {
+    deletepath(file_path).
+  }
+  log log_string to file_path.
+  wait 0.
+  runpath(file_path).
+  deletepath(file_path).
 }

--- a/library/lib_exec.ks
+++ b/library/lib_exec.ks
@@ -121,8 +121,9 @@ function get_suffix {
   set filePath to path(filePath + ".tmp").
   log_run_del(logStr + ". }.",filePath).
   local result is _evaluate_result:call(structure).
-  if defined unset _exec__param_list.
-  unset _evaluate_result.
+  if defined _exec__param_list {
+   unset _exec__param_list.
+  }
   return result.
 }
 
@@ -135,7 +136,7 @@ function set_suffix {
   local logStr IS "global _evaluate_result is { parameter o,v. set o:" + suffix + " to v. }.".
   log_run_del(logStr,filePath).
   local result is _evaluate_result:call(structure,val).
-  if defined unset _evaluate_result.
+  unset _evaluate_result.
 }
 
 local function log_run_del
@@ -143,8 +144,7 @@ local function log_run_del
   parameter
     log_string,//the string to be executed
     file_path. //the path to where the string should be stored temporarily so it can be executed.
-  if exists(file_path)
-  {
+  if exists(file_path) {
     deletepath(file_path).
   }
   log log_string to file_path.

--- a/library/lib_exec.ks
+++ b/library/lib_exec.ks
@@ -92,10 +92,11 @@ function evaluate_function {
     set index to index + 1.
   }
   set expression to function_name + "(" + expression + ")".
+  local result is evaluate(expression).
   if defined _exec__param_list {
     unset _exec__param_list.
   }
-  return evaluate(expression).
+  return result.
 }
 
 function get_suffix {
@@ -103,6 +104,7 @@ function get_suffix {
     structure, //the structure to get the suffix of
     suffix,    //the suffix to get
     parameter_list IS false. //if the suffix is a function call this is the list of parameters for the suffix
+	
   local filePath is "1:/_get_suffix" + suffix.
   local logStr IS "global _evaluate_result is { parameter o. return o:" + suffix.
   if parameter_list:istype("list") {
@@ -132,17 +134,20 @@ function set_suffix {
     structure, //the structure to set the suffix of
     suffix,    //the suffix to set
     val.       //the value to set the suffix to
+	
   local filePath is path("1:/_set_suffix" + suffix + ".tmp").
   local logStr IS "global _evaluate_result is { parameter o,v. set o:" + suffix + " to v. }.".
   log_run_del(logStr,filePath).
   local result is _evaluate_result:call(structure,val).
   unset _evaluate_result.
+  return result.
 }
 
 local function log_run_del{
   parameter
     log_string,//the string to be executed
     file_path. //the path to where the string should be stored temporarily so it can be executed.
+	
   if exists(file_path) {
     deletepath(file_path).
   }

--- a/library/lib_exec.ks
+++ b/library/lib_exec.ks
@@ -31,8 +31,7 @@ if not (defined _past_exec_strings) {
   set _past_exec_strings:casesensitive to true.
 }
 
-function execute
-{
+function execute {
   parameter command.
 
   local filePath IS path().
@@ -67,8 +66,7 @@ function execute
   log_run_del(command,filePath).
 }
 
-function evaluate
-{
+function evaluate {
   parameter expression.
 
   execute("global _evaluate_result is " + expression + ".").
@@ -77,8 +75,7 @@ function evaluate
   return result.
 }
 
-function evaluate_function
-{
+function evaluate_function {
   parameter
     function_name,
     parameter_list.
@@ -87,14 +84,15 @@ function evaluate_function
   local expression is "".
   local separator is "".
   local index is 0.
-  until index = parameter_list:length
-  {
+  until index = parameter_list:length {
     set expression to expression + separator + "_exec__param_list[" + index + "]".
     set separator to ", ".
     set index to index + 1.
   }
   set expression to function_name + "(" + expression + ")".
-  unset _exec__param_list.
+  if defined _exec__param_list {
+    unset _exec__param_list.
+  }
   return evaluate(expression).
 }
 
@@ -122,7 +120,7 @@ function get_suffix {
   log_run_del(logStr + ". }.",filePath).
   local result is _evaluate_result:call(structure).
   if defined _exec__param_list {
-   unset _exec__param_list.
+    unset _exec__param_list.
   }
   return result.
 }
@@ -139,8 +137,7 @@ function set_suffix {
   unset _evaluate_result.
 }
 
-local function log_run_del
-{
+local function log_run_del{
   parameter
     log_string,//the string to be executed
     file_path. //the path to where the string should be stored temporarily so it can be executed.

--- a/library/lib_exec.ks
+++ b/library/lib_exec.ks
@@ -122,6 +122,18 @@ function get_suffix {
   return result.
 }
 
+function set_suffix {
+  parameter
+    structure, //the structure to set the suffix of
+    suffix,    //the suffix to set
+    val.       //the value to set the suffix to
+  local filePath is path("1:/_set_suffix" + suffix + ".tmp").
+  local logStr IS "global _exec__set_suffix_ is { parameter o,v. set o:" + suffix + " to v. }.".
+  log_run_del(logStr,filePath).
+  local result is _exec__set_suffix_:call(structure,val).
+  if defined unset _exec__set_suffix_.
+}
+
 local function log_run_del
 {
   parameter

--- a/library/lib_exec.ks
+++ b/library/lib_exec.ks
@@ -94,6 +94,34 @@ function evaluate_function
   return evaluate(expression).
 }
 
+function get_suffix {
+  parameter
+    structure, //the structure to get the suffix of
+    suffix,    //the suffix to get
+    parameter_list IS false. //if the suffix is a function call this is the list of parameters for the suffix
+  local filePath is "1:/_get_suffix" + suffix.
+  local logStr IS "global _exec__get_suffix_ is { parameter o. return o:" + suffix.
+  if parameter_list:istype("list") {
+    set filePath to filePath + parameter_list:length.
+    local separator is "(".
+    global _exec__param_list IS parameter_list.
+    local i IS 0.
+    until i >= parameter_list:length
+    {
+      set logStr to logStr + separator + "_exec__param_list[" + i + "]".
+      set separator to ", ".
+      set i to i + 1.
+    }
+    set logStr to logStr + ")".
+  }
+  set filePath to path(filePath + ".tmp").
+  log_run_del(logStr + ". }.",filePath).
+  local result is _exec__get_suffix_:call(structure).
+  if defined unset _exec__param_list.
+  unset _exec__get_suffix_.
+  return result.
+}
+
 local function log_run_del
 {
   parameter

--- a/library/lib_exec.ks
+++ b/library/lib_exec.ks
@@ -71,7 +71,9 @@ function evaluate {
 
   execute("global _evaluate_result is " + expression + ".").
   local result is _evaluate_result.
-  unset _evaluate_result.
+  if defined _evaluate_result {
+    unset _evaluate_result.
+  }
   return result.
 }
 

--- a/unit_tests/lib_exec/README.md
+++ b/unit_tests/lib_exec/README.md
@@ -6,7 +6,7 @@ A unit test for all edge cases of lib_exec I know.
 
 **ATTENTION:** The test is split into several files for the purity of the experiment.
 **DO NOT** run them from one script and **DO NOT** merge them into one file.
-run all three tests from the terminal.
+run all four tests from the terminal.
 
 ### instructions:
 * copy all files from "unit_tests/lib_exec/" and "library/lib_exec.ks"

--- a/unit_tests/lib_exec/README.md
+++ b/unit_tests/lib_exec/README.md
@@ -12,6 +12,7 @@ run all three tests from the terminal.
 * copy all files from "unit_tests/lib_exec/" and "library/lib_exec.ks"
   to the archive ("<ksp_folder>/Ships/Script")
 * switch to 0.
+* run test_lib_exec_0.
 * run test_lib_exec_1.
 * run test_lib_exec_2.
 * run test_lib_exec_3.

--- a/unit_tests/lib_exec/test_lib_exec_0.ks
+++ b/unit_tests/lib_exec/test_lib_exec_0.ks
@@ -72,17 +72,34 @@ assert(evaluate("evaluate(expr)") = (12 * 3)).
 
 global i is 0.
 local y is 0.
-until i >= 500 {//this may take time
+until i >= 500 {//checks repetition of the same execution string,this may take time
   execute("set i to i + 1.").
-  if y > 3000 {
+  if y > 600 {
     break.
   } else {
     set y to y + 1.
   }
+  assert(i = y).
 }
-assert(i >= 500).
-IF DEFINED i { unset i. }
-IF DEFINED y { unset y. }
+assert(y = 500).
+
+set i to 0.
+set z to 0.
+
+until i >= 500 {//checks repetition of unique execution strings
+  if z >600 {
+    break.
+  } else {
+    set z to z + 1.
+  }
+  execute("set i to " + z + ".").
+  assert(i = z).
+}
+
+assert(z = 500).
+
+if defined i { unset i. }
+if defined y { unset y. }
 
 // misc
 

--- a/unit_tests/lib_exec/test_lib_exec_0.ks
+++ b/unit_tests/lib_exec/test_lib_exec_0.ks
@@ -68,6 +68,38 @@ assert(recursive(20) = 8).
 set expr to "12 * 3".
 assert(evaluate("evaluate(expr)") = (12 * 3)).
 
+// checking evaluate_function
+
+function sqr {
+  parameter n.
+  return n * n.
+}
+
+assert(evaluate_function("sqr",list(5)) = sqr(5)).
+assert(evaluate_function("sqr",list(10)) = sqr(10)).
+
+//checking recursion
+
+function factorial_exec {
+  parameter n.
+  if n > 1 {
+    return n * evaluate_function("factorial_exec",list(n - 1)).
+  } else {
+    return n.
+  }
+}
+
+function factorial {
+  parameter n.
+  if n > 1 {
+    return n * factorial(n - 1).
+  } else {
+    return n.
+  }
+}
+
+assert(evaluate_function("factorial_exec",list(5)) = factorial(5)).
+
 // case sensitivity check of the caching
 
 execute("set s0 to " + char(34) + char(unchar("A")) + char(34) + ".").

--- a/unit_tests/lib_exec/test_lib_exec_0.ks
+++ b/unit_tests/lib_exec/test_lib_exec_0.ks
@@ -68,6 +68,13 @@ assert(recursive(20) = 8).
 set expr to "12 * 3".
 assert(evaluate("evaluate(expr)") = (12 * 3)).
 
+// case sensitivity check of the caching
+
+execute("set s0 to " + char(34) + char(unchar("A")) + char(34) + ".").
+set s1 to s0.
+execute("set s0 to " + char(34) + char(unchar("a")) + char(34) + ".").
+assert(unchar(s0) <> unchar(s1)).
+
 // need to be able to run execute function many times thus this test checks you can.
 
 global i is 0.

--- a/unit_tests/lib_exec/test_lib_exec_2.internal_1.ks
+++ b/unit_tests/lib_exec/test_lib_exec_2.internal_1.ks
@@ -3,6 +3,7 @@
 run lib_exec.
 run lib_testing.
 
+SET test_lib_exec_2_internal_ran TO TRUE.
 assert(evaluate("true")).
 assert(evaluate("1024") = 1024).
 assert(evaluate("4096") = 4096).

--- a/unit_tests/lib_exec/test_lib_exec_2.ks
+++ b/unit_tests/lib_exec/test_lib_exec_2.ks
@@ -5,8 +5,10 @@ run lib_testing.
 
 // importing (running) lib_exec from inside execute should work to
 
+SET test_lib_exec_2_internal_ran TO FALSE.
 execute("run test_lib_exec_2.internal_1.ks.").
 
+assert(test_lib_exec_2_internal_ran).
 assert(evaluate("true")).
 assert(evaluate("24") = 24).
 assert(evaluate("999" = 999)).

--- a/unit_tests/lib_exec/test_lib_exec_3.ks
+++ b/unit_tests/lib_exec/test_lib_exec_3.ks
@@ -1,0 +1,42 @@
+// This file is distributed under the terms of the MIT license, (c) the KSLib team
+
+run lib_exec.
+run lib_testing.
+
+//testing for get_suffix and set_suffix
+
+//checking get_suffix
+assert(get_suffix(ship,"mass") = ship:mass).
+
+//suffixes should work on the returned structure
+assert(get_suffix(ship,"parts"):length = ship:parts:length).
+
+//should be able to chain more than one get together
+assert(get_suffix(get_suffix(ship,"parts"),"length") = ship:parts:length).
+
+//checking the parameter passing for suffixes that are functions
+local result is get_suffix(body,"geopositionlatlng",list(1,2)).
+assert(result:lat = 1 AND result:lng = 2).
+
+local result is get_suffix(body,"geopositionlatlng",list(3,4)).
+assert(result:lat = 3 AND result:lng = 4).
+
+set core:tag to "".
+
+set_suffix(core,"tag","exec").
+assert(get_suffix(core,"tag") = "exec").
+set_suffix(core,"tag","test").
+assert(get_suffix(core,"tag") = "test").
+
+set core:tag to "".
+
+//TODO: add get and set checks for lexicon
+
+local testLex IS lexicon().
+
+set_suffix(testLex,"one",1).
+assert(testLex:haskey("one")).
+assert(get_suffix(testLex,"one") = 1).
+
+
+test_success().


### PR DESCRIPTION
*added*
  get_suffix function, for getting a suffix of a structure 
  set_suffix function, for setting the suffix of a structure

*changed*
  made all files to be executed by this lib explicitly be created on the local volume as apposed to the working directory
  execute function, moved file creation, execution, and removal into the local function log_run_del
  execute function, added a lexicon to map between executed strings and file names to avoid redundant file creation and potential memory leak


updated documentation and unit tests to include new functions and added a few warnings relating to
