### PR TITLE
Location constants

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -21,8 +21,9 @@ This is an attempt at summarising and categorising the libraries by their use ca
 
 ### Navigation
 1. [lib_circle_nav.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_circle_nav.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_circle_nav.md) : provides functions to help with great circle / geodesic navigation while in atmosphere or the surface. For example, finding out the compass heading of a waypoint to fly there along the shortest path.
-2. [lib_navball.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_navball.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_navball.md) : provides various navball state values (heading, pitch, roll, etc) of several kOS structures that can be considered to have such state.
-3. [lib_navigation.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_navigation.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_navigation.md) : provides a range of functions to used in calculations of both space, atmospheric and surface navigation.
+2. [lib_location_constants.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_location_constants.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_location_constants.md) : provides latitude longitude values for various locations on some bodies.
+3. [lib_navball.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_navball.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_navball.md) : provides various navball state values (heading, pitch, roll, etc) of several kOS structures that can be considered to have such state.
+4. [lib_navigation.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_navigation.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_navigation.md) : provides a range of functions to used in calculations of both space, atmospheric and surface navigation.
 
 ### Programming Utilities
 1. [lib_exec.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_exec.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_exec.md) : allows executing commands and evaluating expressions from strings.

--- a/doc/lib_location_constants.md
+++ b/doc/lib_location_constants.md
@@ -5,7 +5,7 @@ would be relatively easy to locate for players flying manually (i.e., without
 the use of scripting mods such as kOS). The locations in this file are not
 authoritative; feel free to submit updates if you find them inaccurate.
 Additions (new locations, including on bodies other than Kerbin or even
-non-stock bodies) are welcome,
+on non-stock bodies such as Earth or Gael) are welcome,
 but you are advised to check with the KSLib developers (e.g., by submitting a
 feature request) before adding locations of easter eggs that were originally
 intended to be difficult to locate.
@@ -23,7 +23,7 @@ intended to be difficult to locate.
   (although the same could be said for playing KSP). Warning: landing here will
   **not** allow you to recover 100% funds.
 
-#### Runway naming convention
+### Runway naming convention
 
 **tl;dr** `runway_start` is where airplanes normally spawn;
 `reverse_runway_start` is where you want to land if you are heading west
@@ -34,6 +34,8 @@ For more details, consider the relevant
 as of 6 Sept 2020:
 
 >  A runway numbered 09 points east (90°), runway 18 is south (180°), runway 27 points west (270°) and runway 36 points to the north (360° rather than 0°). When taking off from or landing on runway 09, a plane is heading around 90° (east). A runway can normally be used in both directions, and is named for each direction separately: e.g., "runway 15" in one direction is "runway 33" when used in the other. The two numbers differ by 18 (= 180°).
+
+### Horizontal landing locations
 
 * `LocationConstants:dessert_runway_18_start`: alias for
   `desert_runway_18_start`

--- a/doc/lib_location_constants.md
+++ b/doc/lib_location_constants.md
@@ -5,7 +5,7 @@ The locations in this file are not authoritative; feel free to submit updates if
 Additions (new locations, including on bodies other than Kerbin or even on non-stock bodies such as Earth or Gael) are welcome,
 but you are advised to check with the KSLib developers (e.g., by submitting a feature request) before adding locations of easter eggs that were originally intended to be difficult to locate.
 
-### default names
+### Default names
 
 If there is a defined default location for your solar system in the lib then 
 
@@ -23,7 +23,7 @@ as of 6 Sept 2020:
 
 ### Kerbin locations
 
-If using the stock KSP solar system then the default locations are on kerbin the exact location is defined below as `location_constants:launchpad`,`location_constants:runway_start`, and `location_constants:reverse_runway_start`
+If using the stock KSP solar system or the JNSQ system, the default locations are on Kerbin. The exact locations are defined below as `location_constants:launchpad`, `location_constants:runway_start` and `location_constants:reverse_runway_start`.
 
 #### Vertical landing locations
 
@@ -42,11 +42,11 @@ If using the stock KSP solar system then the default locations are on kerbin the
 * `location_constants:reverse_runway_start`: alias for `runway_27_start`.
 
 * `location_constants:kerbin:dessert_runway_18_start`: alias for `desert_runway_18_start`
-* `location_constants:kerbin:desert_runway_18_start`: start of the desert runway when heading north. Roughly where planes spawn when "Dessert Airfield" is selected (only possible if you have the Making History DLC and have adjusted your difficulty settings to allow spawning in other sites).
+* `location_constants:kerbin:desert_runway_18_start`: start of the desert runway when heading south. Roughly where planes spawn when "Dessert Airfield" is selected (only possible if you have the Making History DLC and have adjusted your difficulty settings to allow spawning in other sites).
 * `location_constants:kerbin:dessert_runway_18_end`: alias for `desert_runway_36_start`
 * `location_constants:kerbin:desert_runway_18_end`: alias for `desert_runway_36_start`
 * `location_constants:kerbin:dessert_runway_36_start`: alias for `desert_runway_36_start`
-* `location_constants:kerbin:desert_runway_36_start`: start of the desert runway when heading south.
+* `location_constants:kerbin:desert_runway_36_start`: start of the desert runway when heading north.
 * `location_constants:kerbin:desert_runway_36_end`: alias for `desert_runway_18_start`
 * `location_constants:kerbin:dessert_runway_36_end`: alias for `desert_runway_18_start`
 * `location_constants:kerbin:island_runway_09_start`: start of the island runway when heading east.
@@ -66,7 +66,7 @@ If using the stock KSP solar system then the default locations are on kerbin the
 * `location_constants:kerbin:l2_runway_27_end`: alias for `l2_runway_09_start`
 * `location_constants:kerbin:runway_09_start`: start of the fully upgraded KSC runway.
 * `location_constants:kerbin:runway_09_end`: alias for `runway_27_start`
-* `location_constants:kerbin:runway_27_start`: start of the KSC runway when headed
+* `location_constants:kerbin:runway_27_start`: start of the KSC runway when heading west.
 * `location_constants:kerbin:runway_27_end`: alias for `runway_09_start` west (toward the mountains).
 * `location_constants:kerbin:runway_09_overrun`: The "lip" of the fully-upgraded KSC runway. Certain plane designs that can maintain level flight but cannot pitch up while landed should start pitching up when their wheels pass `runway_09_end`, since the lip will leave them airborne for a moment.
 * `location_constants:kerbin:runway_27_overrun`: The lip of the fully-upgraded KSC runway when headed toward the mountains. Mostly included for symmetry.

--- a/doc/lib_location_constants.md
+++ b/doc/lib_location_constants.md
@@ -1,74 +1,72 @@
 ## `lib_location_constants`
 
-The `lib_location_constants.ks` library provides geolocations for places that
-would be relatively easy to locate for players flying manually (i.e., without
-the use of scripting mods such as kOS). The locations in this file are not
-authoritative; feel free to submit updates if you find them inaccurate.
-Additions (new locations, including on bodies other than Kerbin or even
-on non-stock bodies such as Earth or Gael) are welcome,
-but you are advised to check with the KSLib developers (e.g., by submitting a
-feature request) before adding locations of easter eggs that were originally
-intended to be difficult to locate.
+The `lib_location_constants.ks` library provides geolocations for places that would be relatively easy to locate for players flying manually (i.e., without the use of scripting mods such as kOS).
+The locations in this file are not authoritative; feel free to submit updates if you find them inaccurate.
+Additions (new locations, including on bodies other than Kerbin or even on non-stock bodies such as Earth or Gael) are welcome,
+but you are advised to check with the KSLib developers (e.g., by submitting a feature request) before adding locations of easter eggs that were originally intended to be difficult to locate.
 
-### Vertical landing locations
+### default names
 
-* `LocationConstants:launchpad`: the geolocation of the launchpad
-* `LocationConstants:woomerang_launchpad`: the geolocation of the Woomerang
-  launchpad (northern launchpad surrounded by mountains)
-* `LocationConstants:dessert_launchpad`: alias for `desert_launchpad`
-* `LocationConstants:desert_launchpad`: the launchpad in the Dessert Airfield
-  location, which is in the middle of the desert.
-* `LocationConstants:VAB`: the geolocation of the double helipad on top of the
-  VAB. Don't land here if you care about the safety of your Kerbals at all
-  (although the same could be said for playing KSP). Warning: landing here will
-  **not** allow you to recover 100% funds.
+If there is a defined default location for your solar system in the lib then 
 
-### Runway naming convention
+* `location_constants:runway_start` is the default location where airplanes normally spawn.
+* `location_constants:reverse_runway_start` is the other end of the runway where airplanes normally spawn.
+* `location_constants:launchpad` is the default location where rockets normally spawn.
 
-**tl;dr** `runway_start` is where airplanes normally spawn;
-`reverse_runway_start` is where you want to land if you are heading west
-(toward the mountains) instead of east.
+### Runway naming conventions
 
-For more details, consider the relevant
+More detailed locations are described using the runway heading standards.
 [Wikipedia passage](https://en.wikipedia.org/wiki/Runway#Runway_headings)
 as of 6 Sept 2020:
 
 >  A runway numbered 09 points east (90°), runway 18 is south (180°), runway 27 points west (270°) and runway 36 points to the north (360° rather than 0°). When taking off from or landing on runway 09, a plane is heading around 90° (east). A runway can normally be used in both directions, and is named for each direction separately: e.g., "runway 15" in one direction is "runway 33" when used in the other. The two numbers differ by 18 (= 180°).
 
-### Horizontal landing locations
+### Kerbin locations
 
-* `LocationConstants:dessert_runway_18_start`: alias for
-  `desert_runway_18_start`
-* `LocationConstants:desert_runway_18_start`: start of the desert runway when
-  heading north. Roughly where planes spawn when "Dessert Airfield" is selected
-  (only possible if you have the Making History DLC and have adjusted your
-  difficulty settings to allow spawning in other sites).
-* `LocationConstants:dessert_runway_36_start`: alias for
-  `desert_runway_36_start`
-* `LocationConstants:desert_runway_36_start`: start of the desert runway when
-  heading south.
-* `LocationConstants:island_runway_09_start`: start of the island runway when
-  heading east. Warning: landing here will **not** allow you to recover 100%
-  funds.
-* `LocationConstants:island_runway_27_start`: start of the island runway when
-  heading west. Warning: landing here will **not** allow you to recover 100%
-  funds.
-* `LocationConstants:l1_runway_09_start`: where the KSC runway starts when it
-  has never been upgraded at all (still made of dirt).
-* `LocationConstants:l1_runway_27_start`: start of the un-upgraded (dirt) runway
-  when heading west.
-* `LocationConstants:l2_runway_09_start`: where the KSC runway starts when
-  upgraded once (paved, but with potholes and not lined with lights).
-* `LocationConstants:l2_runway_27_start`: start of the partly upgraded
-  (potholed) runway when heading west.
-* `LocationConstants:runway_start`: alias for `runway_09_start`
-* `LocationConstants:runway_09_start`: start of the fully upgraded KSC runway.
-* `LocationConstants:reverse_runway_start`: alias for `runway_27_start`.
-* `LocationConstants:runway_27_start`: start of the KSC runway when headed
-  west (toward the mountains).
-* `LocationConstants:runway_09_end`: The "lip" of the fully-upgraded KSC
-  runway. Certain plane designs that can maintain level flight but cannot
-  pitch up while landed should start pitching up when their wheels pass
-  `runway_09_end`, since the lip will leave them airborne for a moment.
-* `LocationConstants:runway_27_end`: The lip of the fully-upgraded KSC
-  runway when headed toward the mountains. Mostly included for symmetry.
+If using the stock KSP solar system then the default locations are on kerbin the exact location is defined below as `location_constants:launchpad`,`location_constants:runway_start`, and `location_constants:reverse_runway_start`
+
+#### Vertical landing locations
+
+* `location_constants:launchpad`: alias for `launchpad`
+* `location_constants:kerbin:launchpad`: the geolocation of the launchpad
+* `location_constants:kerbin:woomerang_launchpad`: the geolocation of the Woomerang launchpad (northern launchpad surrounded by mountains)
+* `location_constants:kerbin:dessert_launchpad`: alias for `desert_launchpad`
+* `location_constants:kerbin:desert_launchpad`: the launchpad in the Dessert Airfield location, which is in the middle of the desert.
+* `location_constants:kerbin:VAB`: the geolocation of the double helipad on top of the VAB. Don't land here if you care about the safety of your Kerbals at all (although the same could be said for playing KSP).
+  Warning: landing here will **not** allow you to recover 100% funds.
+
+
+#### Horizontal landing locations
+
+* `location_constants:runway_start`: alias for `runway_09_start`
+* `location_constants:reverse_runway_start`: alias for `runway_27_start`.
+
+* `location_constants:kerbin:dessert_runway_18_start`: alias for `desert_runway_18_start`
+* `location_constants:kerbin:desert_runway_18_start`: start of the desert runway when heading north. Roughly where planes spawn when "Dessert Airfield" is selected (only possible if you have the Making History DLC and have adjusted your difficulty settings to allow spawning in other sites).
+* `location_constants:kerbin:dessert_runway_18_end`: alias for `desert_runway_36_start`
+* `location_constants:kerbin:desert_runway_18_end`: alias for `desert_runway_36_start`
+* `location_constants:kerbin:dessert_runway_36_start`: alias for `desert_runway_36_start`
+* `location_constants:kerbin:desert_runway_36_start`: start of the desert runway when heading south.
+* `location_constants:kerbin:desert_runway_36_end`: alias for `desert_runway_18_start`
+* `location_constants:kerbin:dessert_runway_36_end`: alias for `desert_runway_18_start`
+* `location_constants:kerbin:island_runway_09_start`: start of the island runway when heading east.
+  Warning: landing here will **not** allow you to recover 100% funds.
+* `location_constants:kerbin:island_runway_09_end`: alias for `island_runway_27_start`
+* `location_constants:kerbin:island_runway_27_start`: start of the island runway when heading west.
+  Warning: landing here will **not** allow you to recover 100% funds.
+* `location_constants:kerbin:island_runway_27_end`: alias for `island_runway_09_start`
+* `location_constants:kerbin:l1_runway_09_start`: where the KSC runway starts when it has never been upgraded at all
+  (still made of dirt).
+* `location_constants:kerbin:l1_runway_09_end`: alias for `l1_runway_27_start`
+* `location_constants:kerbin:l1_runway_27_start`: start of the un-upgraded (dirt) runway when heading west.
+* `location_constants:kerbin:l1_runway_27_end`: alias for `l1_runway_09_start`
+* `location_constants:kerbin:l2_runway_09_start`: where the KSC runway starts when upgraded once (paved, but with potholes and not lined with lights).
+* `location_constants:kerbin:l2_runway_09_end`: alias for `l2_runway_27_start`
+* `location_constants:kerbin:l2_runway_27_start`: start of the partly upgraded (potholed) runway when heading west.
+* `location_constants:kerbin:l2_runway_27_end`: alias for `l2_runway_09_start`
+* `location_constants:kerbin:runway_09_start`: start of the fully upgraded KSC runway.
+* `location_constants:kerbin:runway_09_end`: alias for `runway_27_start`
+* `location_constants:kerbin:runway_27_start`: start of the KSC runway when headed
+* `location_constants:kerbin:runway_27_end`: alias for `runway_09_start` west (toward the mountains).
+* `location_constants:kerbin:runway_09_overrun`: The "lip" of the fully-upgraded KSC runway. Certain plane designs that can maintain level flight but cannot pitch up while landed should start pitching up when their wheels pass `runway_09_end`, since the lip will leave them airborne for a moment.
+* `location_constants:kerbin:runway_27_overrun`: The lip of the fully-upgraded KSC runway when headed toward the mountains. Mostly included for symmetry.

--- a/doc/lib_location_constants.md
+++ b/doc/lib_location_constants.md
@@ -1,0 +1,72 @@
+## `lib_location_constants`
+
+The `lib_location_constants.ks` library provides geolocations for places that
+would be relatively easy to locate for players flying manually (i.e., without
+the use of scripting mods such as kOS). The locations in this file are not
+authoritative; feel free to submit updates if you find them inaccurate.
+Additions (new locations, including on bodies other than Kerbin or even
+non-stock bodies) are welcome,
+but you are advised to check with the KSLib developers (e.g., by submitting a
+feature request) before adding locations of easter eggs that were originally
+intended to be difficult to locate.
+
+### Vertical landing locations
+
+* `LocationConstants:launchpad`: the geolocation of the launchpad
+* `LocationConstants:woomerang_launchpad`: the geolocation of the Woomerang
+  launchpad (northern launchpad surrounded by mountains)
+* `LocationConstants:dessert_launchpad`: alias for `desert_launchpad`
+* `LocationConstants:desert_launchpad`: the launchpad in the Dessert Airfield
+  location, which is in the middle of the desert.
+* `LocationConstants:VAB`: the geolocation of the double helipad on top of the
+  VAB. Don't land here if you care about the safety of your Kerbals at all
+  (although the same could be said for playing KSP). Warning: landing here will
+  **not** allow you to recover 100% funds.
+
+#### Runway naming convention
+
+**tl;dr** `runway_start` is where airplanes normally spawn;
+`reverse_runway_start` is where you want to land if you are heading west
+(toward the mountains) instead of east.
+
+For more details, consider the relevant
+[Wikipedia passage](https://en.wikipedia.org/wiki/Runway#Runway_headings)
+as of 6 Sept 2020:
+
+>  A runway numbered 09 points east (90°), runway 18 is south (180°), runway 27 points west (270°) and runway 36 points to the north (360° rather than 0°). When taking off from or landing on runway 09, a plane is heading around 90° (east). A runway can normally be used in both directions, and is named for each direction separately: e.g., "runway 15" in one direction is "runway 33" when used in the other. The two numbers differ by 18 (= 180°).
+
+* `LocationConstants:dessert_runway_18_start`: alias for
+  `desert_runway_18_start`
+* `LocationConstants:desert_runway_18_start`: start of the desert runway when
+  heading north. Roughly where planes spawn when "Dessert Airfield" is selected
+  (only possible if you have the Making History DLC and have adjusted your
+  difficulty settings to allow spawning in other sites).
+* `LocationConstants:dessert_runway_36_start`: alias for
+  `desert_runway_36_start`
+* `LocationConstants:desert_runway_36_start`: start of the desert runway when
+  heading south.
+* `LocationConstants:island_runway_09_start`: start of the island runway when
+  heading east. Warning: landing here will **not** allow you to recover 100%
+  funds.
+* `LocationConstants:island_runway_27_start`: start of the island runway when
+  heading west. Warning: landing here will **not** allow you to recover 100%
+  funds.
+* `LocationConstants:l1_runway_09_start`: where the KSC runway starts when it
+  has never been upgraded at all (still made of dirt).
+* `LocationConstants:l1_runway_27_start`: start of the un-upgraded (dirt) runway
+  when heading west.
+* `LocationConstants:l2_runway_09_start`: where the KSC runway starts when
+  upgraded once (paved, but with potholes and not lined with lights).
+* `LocationConstants:l2_runway_27_start`: start of the partly upgraded
+  (potholed) runway when heading west.
+* `LocationConstants:runway_start`: alias for `runway_09_start`
+* `LocationConstants:runway_09_start`: start of the fully upgraded KSC runway.
+* `LocationConstants:reverse_runway_start`: alias for `runway_27_start`.
+* `LocationConstants:runway_27_start`: start of the KSC runway when headed
+  west (toward the mountains).
+* `LocationConstants:runway_09_end`: The "lip" of the fully-upgraded KSC
+  runway. Certain plane designs that can maintain level flight but cannot
+  pitch up while landed should start pitching up when their wheels pass
+  `runway_09_end`, since the lip will leave them airborne for a moment.
+* `LocationConstants:runway_27_end`: The lip of the fully-upgraded KSC
+  runway when headed toward the mountains. Mostly included for symmetry.

--- a/examples/example_lib_location_constants.ks
+++ b/examples/example_lib_location_constants.ks
@@ -4,9 +4,9 @@ runpath("0:/KSLib/library/lib_location_constants").
 
 // Compute the distance from the launch pad to the middle of the runway.
 
-local launchpad to LocationConstants:launchpad:position.
-local runway_start to LocationConstants:runway_09_start:position.
-local runway_end to LocationConstants:runway_27_start:position.
+local launchpad to location_constants:kerbin:launchpad:position.
+local runway_start to location_constants:kerbin:runway_09_start:position.
+local runway_end to location_constants:kerbin:runway_09_end:position.
 local desired_distance to vxcl(runway_end - runway_start, launchpad - runway_start):mag.
 
 print "The launch pad is " + round(desired_distance) + " meters from the" +

--- a/examples/example_lib_location_constants.ks
+++ b/examples/example_lib_location_constants.ks
@@ -1,0 +1,13 @@
+@LAZYGLOBAL off.
+
+runpath("0:/KSLib/library/lib_location_constants").
+
+// Compute the distance from the launch pad to the middle of the runway.
+
+local launchpad to LocationConstants:launchpad:position.
+local runway_start to LocationConstants:runway_09_start:position.
+local runway_end to LocationConstants:runway_27_start:position.
+local desired_distance to vxcl(runway_end - runway_start, launchpad - runway_start):mag.
+
+print "The launch pad is " + round(desired_distance) + " meters from the" +
+      " centerline of the runway.".

--- a/library/lib_location_constants.ks
+++ b/library/lib_location_constants.ks
@@ -1,0 +1,35 @@
+@LAZYGLOBAL off.
+
+Global LocationConstants is lex(
+  // vertical landing locations
+  "launchpad", Kerbin:GeoPositionLatLng(-0.0972, -74.5577),
+  "woomerang_launchpad", Kerbin:GeoPositionLatLng(45.2896, 136.1100),
+  "desert_launchpad", Kerbin:GeoPositionLatLng(-6.5604, -143.9500),
+  "VAB", Kerbin:GeoPositionLatLng(-0.097, -74.619),
+
+  // horizontal landing locations
+  "runway_start", Kerbin:GeoPositionLatLng(-0.0487, -74.7247),
+  "runway_end", Kerbin:GeoPositionLatLng(-0.0501, -74.4880),  // runway "lip"
+  "runway_start_heading_west", Kerbin:GeoPositionLatLng(-0.0501, -74.4925),
+  "runway_end_heading_west", Kerbin:GeoPositionLatLng(-0.0487, -74.7292),  // runway "lip"
+  "runway_l1_start", Kerbin:GeoPositionLatLng(-.0489, -74.7101),
+  "runway_l1_start_heading_west", Kerbin:GeoPositionLatLng(-.0503, -74.5076),
+  "runway_l2_start", Kerbin:GeoPositionLatLng(-.0486, -74.7134),
+  "runway_l2_start_heading_west", Kerbin:GeoPositionLatLng(-.0501, -74.5046),
+  "island_runway_start_heading_east", Kerbin:GeoPositionLatLng(-1.5177, -71.9663),
+  "island_runway_start_heading_west", Kerbin:GeoPositionLatLng(-1.5158, -71.8524),
+  "desert_runway_start", Kerbin:GeoPositionLatLng(-6.5998, -144.0407),
+  "desert_runway_start_heading_south", Kerbin:GeoPositionLatLng(-6.4480, -144.0383)
+).
+
+// aliases
+Set LocationConstants["runway_start_heading_east"] to LocationConstants["runway_start"].
+Set LocationConstants["runway_end_heading_east"] to LocationConstants["runway_end"].
+Set LocationConstants["runway_l1_start_heading_east"] to LocationConstants["runway_l1_start"].
+Set LocationConstants["runway_l2_start_heading_east"] to LocationConstants["runway_l2_start"].
+
+Set LocationConstants["dessert_runway_start"] to LocationConstants["desert_runway_start"].
+Set LocationConstants["dessert_runway_start_heading_south"] to LocationConstants["desert_runway_start_heading_south"].
+Set LocationConstants["desert_runway_start_heading_north"] to LocationConstants["desert_runway_start"].
+Set LocationConstants["dessert_runway_start_heading_north"] to LocationConstants["dessert_runway_start"].
+Set LocationConstants["dessert_launchpad"] to LocationConstants["desert_launchpad"].

--- a/library/lib_location_constants.ks
+++ b/library/lib_location_constants.ks
@@ -1,6 +1,6 @@
 @LAZYGLOBAL off.
 
-Global LocationConstants is lex(
+global LocationConstants is lex(
   // vertical landing locations
   "launchpad", Kerbin:GeoPositionLatLng(-0.0972, -74.5577),
   "woomerang_launchpad", Kerbin:GeoPositionLatLng(45.2896, 136.1100),
@@ -23,12 +23,12 @@ Global LocationConstants is lex(
 ).
 
 // aliases
-Set LocationConstants["runway_start"] to LocationConstants["runway_09_start"].
-Set LocationConstants["reverse_runway_start"] to LocationConstants["runway_27_start"].
+set LocationConstants["runway_start"] to LocationConstants["runway_09_start"].
+set LocationConstants["reverse_runway_start"] to LocationConstants["runway_27_start"].
 
-For key in LocationConstants:keys {
-  If key:contains("desert") {
-    Local alias to key:replace("desert", "dessert").
-    Set LocationConstants[alias] to LocationConstants[key].
+for key in LocationConstants:keys {
+  if key:contains("desert") {
+    local alias to key:replace("desert", "dessert").
+    set LocationConstants[alias] to LocationConstants[key].
   }.
 }.

--- a/library/lib_location_constants.ks
+++ b/library/lib_location_constants.ks
@@ -8,28 +8,27 @@ Global LocationConstants is lex(
   "VAB", Kerbin:GeoPositionLatLng(-0.097, -74.619),
 
   // horizontal landing locations
-  "runway_start", Kerbin:GeoPositionLatLng(-0.0487, -74.7247),
-  "runway_end", Kerbin:GeoPositionLatLng(-0.0501, -74.4880),  // runway "lip"
-  "runway_start_heading_west", Kerbin:GeoPositionLatLng(-0.0501, -74.4925),
-  "runway_end_heading_west", Kerbin:GeoPositionLatLng(-0.0487, -74.7292),  // runway "lip"
-  "runway_l1_start", Kerbin:GeoPositionLatLng(-.0489, -74.7101),
-  "runway_l1_start_heading_west", Kerbin:GeoPositionLatLng(-.0503, -74.5076),
-  "runway_l2_start", Kerbin:GeoPositionLatLng(-.0486, -74.7134),
-  "runway_l2_start_heading_west", Kerbin:GeoPositionLatLng(-.0501, -74.5046),
-  "island_runway_start_heading_east", Kerbin:GeoPositionLatLng(-1.5177, -71.9663),
-  "island_runway_start_heading_west", Kerbin:GeoPositionLatLng(-1.5158, -71.8524),
-  "desert_runway_start", Kerbin:GeoPositionLatLng(-6.5998, -144.0407),
-  "desert_runway_start_heading_south", Kerbin:GeoPositionLatLng(-6.4480, -144.0383)
+  "runway_09_start", Kerbin:GeoPositionLatLng(-0.0487, -74.7247),
+  "runway_09_end", Kerbin:GeoPositionLatLng(-0.0501, -74.4880),  // runway "lip"
+  "runway_27_start", Kerbin:GeoPositionLatLng(-0.0501, -74.4925),
+  "runway_27_end", Kerbin:GeoPositionLatLng(-0.0487, -74.7292),  // runway "lip"
+  "l1_runway_09_start", Kerbin:GeoPositionLatLng(-.0489, -74.7101),
+  "l1_runway_27_start", Kerbin:GeoPositionLatLng(-.0503, -74.5076),
+  "l2_runway_09_start", Kerbin:GeoPositionLatLng(-.0486, -74.7134),
+  "l2_runway_27_start", Kerbin:GeoPositionLatLng(-.0501, -74.5046),
+  "island_runway_09_start", Kerbin:GeoPositionLatLng(-1.5177, -71.9663),
+  "island_runway_27_start", Kerbin:GeoPositionLatLng(-1.5158, -71.8524),
+  "desert_runway_36_start", Kerbin:GeoPositionLatLng(-6.5998, -144.0407),
+  "desert_runway_18_start", Kerbin:GeoPositionLatLng(-6.4480, -144.0383)
 ).
 
 // aliases
-Set LocationConstants["runway_start_heading_east"] to LocationConstants["runway_start"].
-Set LocationConstants["runway_end_heading_east"] to LocationConstants["runway_end"].
-Set LocationConstants["runway_l1_start_heading_east"] to LocationConstants["runway_l1_start"].
-Set LocationConstants["runway_l2_start_heading_east"] to LocationConstants["runway_l2_start"].
+Set LocationConstants["runway_start"] to LocationConstants["runway_09_start"].
+Set LocationConstants["reverse_runway_start"] to LocationConstants["runway_27_start"].
 
-Set LocationConstants["dessert_runway_start"] to LocationConstants["desert_runway_start"].
-Set LocationConstants["dessert_runway_start_heading_south"] to LocationConstants["desert_runway_start_heading_south"].
-Set LocationConstants["desert_runway_start_heading_north"] to LocationConstants["desert_runway_start"].
-Set LocationConstants["dessert_runway_start_heading_north"] to LocationConstants["dessert_runway_start"].
-Set LocationConstants["dessert_launchpad"] to LocationConstants["desert_launchpad"].
+For key in LocationConstants:keys {
+  If key:contains("desert") {
+    Local alias to key:replace("desert", "dessert").
+    Set LocationConstants[alias] to LocationConstants[key].
+  }.
+}.

--- a/library/lib_location_constants.ks
+++ b/library/lib_location_constants.ks
@@ -5,7 +5,7 @@ global location_constants is lex().
 //runways should be added in this pattern "name_runway_##_start" where name is the name of the runway and ## is the runway number
 //  If not added with this pattern then the automatic alias creation that add an end position based on the start of the same name but opposite number will fail
 
-if bodyexists("kerbin") and bodyexists("mun") and bodyexists("minmus") {//check for if the craft is in the stock solar system
+if bodyexists("Sun") and body("Sun"):radius = 261_600_000 and bodyexists("Kerbin") {//check for if the craft is in the stock solar system
   local kerbinLocations is lex().
   // vertical landing locations
   kerbinLocations:add("launchpad", Kerbin:GeoPositionLatLng(-0.0972, -74.5577)).
@@ -32,6 +32,42 @@ if bodyexists("kerbin") and bodyexists("mun") and bodyexists("minmus") {//check 
   location_constants:add("reverse_runway_start",kerbinLocations["runway_27_start"]).
 
   location_constants:add("kerbin",kerbinLocations).
+}
+
+// JNSQ locations
+if bodyexists("Sun") and body("Sun"):radius = 175_750_000 and bodyexists("Kerbin") {
+  local kerbinLocations is lex().
+  // vertical landing locations
+  kerbinLocations:add("launchpad", Kerbin:GeoPositionLatLng(-1.75133971218638E-08,-91.7839867917987)).
+  kerbinLocations:add("woomerang_launchpad", Kerbin:GeoPositionLatLng(45.2898572995131,136.109991969089)).
+  kerbinLocations:add("desert_launchpad", Kerbin:GeoPositionLatLng(-6.56014471162071,-143.949999962632)).
+  kerbinLocations:add("VAB", Kerbin:GeoPositionLatLng(-3.59779685817755E-05,-91.8082182694506)).
+  location_constants:add("launchpad",kerbinLocations["launchpad"]).
+
+  // horizontal landing locations
+  kerbinLocations:add("runway_09_start", Kerbin:GeoPositionLatLng(0.0177914364838286,-91.8485588846624)).
+  kerbinLocations:add("runway_09_overrun", Kerbin:GeoPositionLatLng(0.017771315430981,-91.7560165023844)).  // runway "lip"
+  kerbinLocations:add("runway_27_start", Kerbin:GeoPositionLatLng(0.0177872750049561,-91.758043638339)).
+  kerbinLocations:add("runway_27_overrun", Kerbin:GeoPositionLatLng(0.0177981075373338,-91.8503058587583)).  // runway "lip"
+  kerbinLocations:add("l1_runway_09_start", Kerbin:GeoPositionLatLng(0.0177201817416171,-91.8418633582038)).
+  kerbinLocations:add("l1_runway_27_start", Kerbin:GeoPositionLatLng(0.0177610480469539,-91.7644480917721)).
+  kerbinLocations:add("l2_runway_09_start", Kerbin:GeoPositionLatLng(0.0178308568526199,-91.8434577819091)).
+  kerbinLocations:add("l2_runway_27_start", Kerbin:GeoPositionLatLng(0.0178110871731228,-91.7632143441808)).
+  kerbinLocations:add("island_runway_09_start", Kerbin:GeoPositionLatLng(-1.5323269901046,-71.9321971014811)).
+  kerbinLocations:add("island_runway_27_start", Kerbin:GeoPositionLatLng(-1.53151635515729,-71.8874890013379)).
+  kerbinLocations:add("desert_runway_36_start", Kerbin:GeoPositionLatLng(-6.55057590520998,-144.040382288094)).
+  kerbinLocations:add("desert_runway_18_start", Kerbin:GeoPositionLatLng(-6.49233191848109,-144.039374890239)).
+
+  location_constants:add("runway_start",kerbinLocations["runway_09_start"]).
+  location_constants:add("reverse_runway_start",kerbinLocations["runway_27_start"]).
+
+  location_constants:add("kerbin",kerbinLocations).
+}
+
+// RealSolarSystem locations
+if bodyexists("Sun") and body("Sun"):radius = 696_342_000 and bodyexists("Earth") {
+  // local earthLocations is lex().
+  // TODO: populate at least the most commonly used of the RealSolarSystem locations.
 }
 
 // aliases

--- a/library/lib_location_constants.ks
+++ b/library/lib_location_constants.ks
@@ -1,34 +1,79 @@
 @LAZYGLOBAL off.
 
-global LocationConstants is lex(
+if not (defined location_constants) {
+global location_constants is lex().
+//runways should be added in this pattern "name_runway_##_start" where name is the name of the runway and ## is the runway number
+//  If not added with this pattern then the automatic alias creation that add an end position based on the start of the same name but opposite number will fail
+
+if bodyexists("kerbin") and bodyexists("mun") and bodyexists("minmus") {//check for if the craft is in the stock solar system
+  local kerbinLocations is lex().
   // vertical landing locations
-  "launchpad", Kerbin:GeoPositionLatLng(-0.0972, -74.5577),
-  "woomerang_launchpad", Kerbin:GeoPositionLatLng(45.2896, 136.1100),
-  "desert_launchpad", Kerbin:GeoPositionLatLng(-6.5604, -143.9500),
-  "VAB", Kerbin:GeoPositionLatLng(-0.097, -74.619),
+  kerbinLocations:add("launchpad", Kerbin:GeoPositionLatLng(-0.0972, -74.5577)).
+  kerbinLocations:add("woomerang_launchpad", Kerbin:GeoPositionLatLng(45.2896, 136.1100)).
+  kerbinLocations:add("desert_launchpad", Kerbin:GeoPositionLatLng(-6.5604, -143.9500)).
+  kerbinLocations:add("VAB", Kerbin:GeoPositionLatLng(-0.0968, -74.6187)).
+  location_constants:add("launchpad",kerbinLocations["launchpad"]).
 
   // horizontal landing locations
-  "runway_09_start", Kerbin:GeoPositionLatLng(-0.0487, -74.7247),
-  "runway_09_end", Kerbin:GeoPositionLatLng(-0.0501, -74.4880),  // runway "lip"
-  "runway_27_start", Kerbin:GeoPositionLatLng(-0.0501, -74.4925),
-  "runway_27_end", Kerbin:GeoPositionLatLng(-0.0487, -74.7292),  // runway "lip"
-  "l1_runway_09_start", Kerbin:GeoPositionLatLng(-.0489, -74.7101),
-  "l1_runway_27_start", Kerbin:GeoPositionLatLng(-.0503, -74.5076),
-  "l2_runway_09_start", Kerbin:GeoPositionLatLng(-.0486, -74.7134),
-  "l2_runway_27_start", Kerbin:GeoPositionLatLng(-.0501, -74.5046),
-  "island_runway_09_start", Kerbin:GeoPositionLatLng(-1.5177, -71.9663),
-  "island_runway_27_start", Kerbin:GeoPositionLatLng(-1.5158, -71.8524),
-  "desert_runway_36_start", Kerbin:GeoPositionLatLng(-6.5998, -144.0407),
-  "desert_runway_18_start", Kerbin:GeoPositionLatLng(-6.4480, -144.0383)
-).
+  kerbinLocations:add("runway_09_start", Kerbin:GeoPositionLatLng(-0.0486, -74.7247)).
+  kerbinLocations:add("runway_09_overrun", Kerbin:GeoPositionLatLng(-0.0502, -74.4880)).  // runway "lip"
+  kerbinLocations:add("runway_27_start", Kerbin:GeoPositionLatLng(-0.0502, -74.4925)).
+  kerbinLocations:add("runway_27_overrun", Kerbin:GeoPositionLatLng(-0.0486, -74.7292)).  // runway "lip"
+  kerbinLocations:add("l1_runway_09_start", Kerbin:GeoPositionLatLng(-.0489, -74.7101)).
+  kerbinLocations:add("l1_runway_27_start", Kerbin:GeoPositionLatLng(-.0501, -74.5076)).
+  kerbinLocations:add("l2_runway_09_start", Kerbin:GeoPositionLatLng(-.0486, -74.7134)).
+  kerbinLocations:add("l2_runway_27_start", Kerbin:GeoPositionLatLng(-.0501, -74.5046)).
+  kerbinLocations:add("island_runway_09_start", Kerbin:GeoPositionLatLng(-1.5177, -71.9663)).
+  kerbinLocations:add("island_runway_27_start", Kerbin:GeoPositionLatLng(-1.5158, -71.8524)).
+  kerbinLocations:add("desert_runway_36_start", Kerbin:GeoPositionLatLng(-6.5998, -144.0409)).
+  kerbinLocations:add("desert_runway_18_start", Kerbin:GeoPositionLatLng(-6.4480, -144.0383)).
+
+  location_constants:add("runway_start",kerbinLocations["runway_09_start"]).
+  location_constants:add("reverse_runway_start",kerbinLocations["runway_27_start"]).
+
+  location_constants:add("kerbin",kerbinLocations).
+}
 
 // aliases
-set LocationConstants["runway_start"] to LocationConstants["runway_09_start"].
-set LocationConstants["reverse_runway_start"] to LocationConstants["runway_27_start"].
+until not aliasing(location_constants) {}.
 
-for key in LocationConstants:keys {
-  if key:contains("desert") {
-    local alias to key:replace("desert", "dessert").
-    set LocationConstants[alias] to LocationConstants[key].
-  }.
-}.
+local function aliasing {
+  parameter locationConstants.
+  local didChange is false.
+  for key in locationConstants:keys {
+    local bodyLex is locationConstants[key].
+    if bodyLex:istype("lexicon") {
+      local bodyKeys is bodyLex:keys:copy.
+      for currentKey in bodyKeys {
+        if currentKey:contains("desert") {//desert to dessert aliasing
+          local alias to currentKey:replace("desert", "dessert").
+          if not bodyLex:haskey(alias) {
+            bodyLex:add(alias,bodyLex[currentKey]).
+            set didChange to true.
+          }
+        }
+
+        if currentKey:matchespattern("runway_\d{1,2}_start$") {//runway_##_end aliasing
+          local alias is currentKey:replace("start", "end").
+          // now find the key that `alias` is an alias of
+          if not bodyLex:haskey(alias) {
+            local splitKey is currentKey:split("_").
+            local currentNum is splitKey[splitKey:length - 2].
+            local reverseNum is MOD(currentNum:toscalar(0) + 18,36):tostring.
+            if reverseNum = "0" { set reverseNum to "36". }
+            local reverseStr is currentKey:replace(currentNum,reverseNum).
+            if not bodyLex:haskey(reverseStr) {
+              set reverseStr to currentKey:replace(currentNum,"0" + reverseNum).
+            }
+            if bodyLex:haskey(reverseStr) {
+              bodyLex:add(alias,bodyLex[reverseStr]).
+              set didChange to true.
+            }
+          }
+        }
+      }
+    }
+  }
+  return didChange.
+}
+}


### PR DESCRIPTION
The `lib_location_constants.ks` library provides geolocations for places that
would be relatively easy to locate for players flying manually (i.e., without
the use of scripting mods such as kOS).