### PR TITLE
Made consistent headers for source, and footers for doc.

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -56,3 +56,7 @@ although feel free to add your own, as long as it doesn't
 get out of hand with too many authors of the same file, in
 which case it may make more sense to just say it was edited
 by a consortium.
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -56,6 +56,7 @@ although feel free to add your own, as long as it doesn't
 get out of hand with too many authors of the same file, in
 which case it may make more sense to just say it was edited
 by a consortium.
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/LIB_MANAGER.md
+++ b/LIB_MANAGER.md
@@ -150,3 +150,7 @@ master. (which means THEY have to do the above steps A, B, and C, instead of
 you, and as the actual person who knows what their PR is about, they are more
 likely to understand the meaning of the conflicts and what the right choice
 is.)
+---
+Copyright © 2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/LIB_MANAGER.md
+++ b/LIB_MANAGER.md
@@ -150,6 +150,7 @@ master. (which means THEY have to do the above steps A, B, and C, instead of
 you, and as the actual person who knows what their PR is about, they are more
 likely to understand the meaning of the conflicts and what the right choice
 is.)
+
 ---
 Copyright © 2019 KSLib team
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The main kOS mod has been released under version 3 of the [GNU General Public Li
 
   1. MOSTLY THIS ONE -> The GNU GPL is verbose.  Applying it significantly increases the size of each Kerboscript source code file, unnecessarily occupying precious kOS disk capacity.
   2. Casual Kerboscript programmers who just want to do something small and simple may find the GNU GPL intimidating.
+
 ---
 Copyright © 2015,2019,2020 KSLib team
 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ The main kOS mod has been released under version 3 of the [GNU General Public Li
 
   1. MOSTLY THIS ONE -> The GNU GPL is verbose.  Applying it significantly increases the size of each Kerboscript source code file, unnecessarily occupying precious kOS disk capacity.
   2. Casual Kerboscript programmers who just want to do something small and simple may find the GNU GPL intimidating.
+---
+Copyright © 2015,2019,2020 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -44,3 +44,7 @@ This is an attempt at summarising and categorising the libraries by their use ca
 9. [lib_seven_seg.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_seven_seg.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_seven_seg.md) : creates a seven segment display to show single digit numbers.
 10. [lib_str_to_num.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_str_to_num.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_str_to_num.md) : converts numerical strings into numbers. This has been superseded by kOS built-in `STRING:TONUMBER()`.
 11. [lib_term.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_term.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_term.md) : a primitive terminal ASCII graphics library. Helps with drawing straight lines, circles and elliptical arcs.
+---
+Copyright © 2019,2020 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -44,6 +44,7 @@ This is an attempt at summarising and categorising the libraries by their use ca
 9. [lib_seven_seg.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_seven_seg.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_seven_seg.md) : creates a seven segment display to show single digit numbers.
 10. [lib_str_to_num.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_str_to_num.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_str_to_num.md) : converts numerical strings into numbers. This has been superseded by kOS built-in `STRING:TONUMBER()`.
 11. [lib_term.ks](https://github.com/KSP-KOS/KSLib/blob/master/library/lib_term.ks) / [docs](https://github.com/KSP-KOS/KSLib/blob/master/doc/lib_term.md) : a primitive terminal ASCII graphics library. Helps with drawing straight lines, circles and elliptical arcs.
+
 ---
 Copyright © 2019,2020 KSLib team
 

--- a/doc/lib_circle_nav.md
+++ b/doc/lib_circle_nav.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_circle_nav.
 
 ``lib_circle_nav.ks`` provides a set of functions that use Great Circle equations. On the surface of a sphere the shortest path between 2 points does not have a constant bearing. Use of these functions either on their own or combined can give you all sorts of details about the "as the crow flies" path between 2 points. Including which way you need to go, how far it is and what you will fly over.
@@ -65,3 +63,7 @@ returns:
 
 description:
   * Gives you the midpoint between point 1 and 2 along a great circle path.
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_circle_nav.md
+++ b/doc/lib_circle_nav.md
@@ -63,6 +63,7 @@ returns:
 
 description:
   * Gives you the midpoint between point 1 and 2 along a great circle path.
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_enum.md
+++ b/doc/lib_enum.md
@@ -355,6 +355,7 @@ function compare_string_descending {
 }
 Enum["sort"](list("foo","foobarbaz", "foobar"), compare_string_descending@). // list("foobarbaz","foobar","foo")
 ```
+
 ---
 Copyright © 2015,2016 KSLib team
 

--- a/doc/lib_enum.md
+++ b/doc/lib_enum.md
@@ -1,32 +1,30 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_enum
 
 ``lib_enum.ks`` provides a set of functions for manipulating lists, queues, and stacks using the new delegates syntax introduced in kOS version 0.19.0. It allows you to transform and execute on lists, queues, and stacks by passing in a delegate function, and is designed to contain all the core components of an enumerable library.
 
 Each of the functions is made available through the `Enum` [lexicon](http://ksp-kos.github.io/KOS_DOC/structures/misc/lexicon.html), to minimize the number of variables used in the global namespace. They can be called using the following syntax: `run lib_enum. Enum["max"](list(1,2,3)). // 3` All functions work on [Lists](http://ksp-kos.github.io/KOS_DOC/structures/misc/list.html), [Stacks](http://ksp-kos.github.io/KOS_DOC/structures/misc/stack.html), and [Queues](http://ksp-kos.github.io/KOS_DOC/structures/misc/queue.html), and when collections are returned, they will be of the same type as the original input.
 
-function        | arguments                     | return type   | description
-----------------| ----------------------------- | ------------- | -----------
-all             | elements, match_fn@           | bool          | Check if all elements return true when passed to the delegate function
-any             | elements, match_fn@           | bool          | Check if any elements return true when passed to the delegate function
-count           | elements, match_fn@           | integer       | Count how many elements return true when passed to the delegate function
-each            | elements, operation_fn@       |               | Call the delegate function with each element of the collection as an argument
-each_slice      | elements, size, operation_fn@ |               | Call the delegate function with fixed-size chunks of the collection passed as an argument
-each_with_index | elements, operation_fn@       |               | Call the delegate function with each element and its index passed as arguments
-find            | elements, match_fn@           | element       | Return the first item in the collection for which the delegate returns true
-find_index      | elements, match_fn@           | integer       | Return the index of the first item in the collection for which the delegate returns true
-group_by        | elements, transform_fn@       | Lexicon       | Return a lexicon that maps the return values of the delegate to each element in the collection
-map             | elements, transform_fn@       | collection    | Return a new collection  with the return values of the delegate called with each element
-map_with_index  | elements, transform_fn@       | collection    | Return a new collection  with the return values of the delegate called with each element and index
-max             | elements                      | element       | Return the largest value in the collection
-min             | elements                      | element       | Return the smallest value in the collection
-partition       | elements, match_fn@           | List          | Return a list of collections, splitting the original collection by the delegate's true/false result
-reduce          | elements, value, reduce_fn@   | final value   | Combine all the values of a collection via binary operations, seeded with the starting value
-reject          | elements, match_fn@           | collection    | Return a new collection with all items for which the delegate returns false
-reverse         | elements                      | collection    | Return a copy of the collection with elements reversed
-select          | elements, match_fn@           | collection    | Return a new collection with all items for which the delegate returns true
-sort            | elements, compare_fn@         | collection    | Return a new collection with the original elements sorted by the delegate
+| function        | arguments                     | return type | description                                                                                         |
+| --------------- | ----------------------------- | ----------- | --------------------------------------------------------------------------------------------------- |
+| all             | elements, match_fn@           | bool        | Check if all elements return true when passed to the delegate function                              |
+| any             | elements, match_fn@           | bool        | Check if any elements return true when passed to the delegate function                              |
+| count           | elements, match_fn@           | integer     | Count how many elements return true when passed to the delegate function                            |
+| each            | elements, operation_fn@       |             | Call the delegate function with each element of the collection as an argument                       |
+| each_slice      | elements, size, operation_fn@ |             | Call the delegate function with fixed-size chunks of the collection passed as an argument           |
+| each_with_index | elements, operation_fn@       |             | Call the delegate function with each element and its index passed as arguments                      |
+| find            | elements, match_fn@           | element     | Return the first item in the collection for which the delegate returns true                         |
+| find_index      | elements, match_fn@           | integer     | Return the index of the first item in the collection for which the delegate returns true            |
+| group_by        | elements, transform_fn@       | Lexicon     | Return a lexicon that maps the return values of the delegate to each element in the collection      |
+| map             | elements, transform_fn@       | collection  | Return a new collection  with the return values of the delegate called with each element            |
+| map_with_index  | elements, transform_fn@       | collection  | Return a new collection  with the return values of the delegate called with each element and index  |
+| max             | elements                      | element     | Return the largest value in the collection                                                          |
+| min             | elements                      | element     | Return the smallest value in the collection                                                         |
+| partition       | elements, match_fn@           | List        | Return a list of collections, splitting the original collection by the delegate's true/false result |
+| reduce          | elements, value, reduce_fn@   | final value | Combine all the values of a collection via binary operations, seeded with the starting value        |
+| reject          | elements, match_fn@           | collection  | Return a new collection with all items for which the delegate returns false                         |
+| reverse         | elements                      | collection  | Return a copy of the collection with elements reversed                                              |
+| select          | elements, match_fn@           | collection  | Return a new collection with all items for which the delegate returns true                          |
+| sort            | elements, compare_fn@         | collection  | Return a new collection with the original elements sorted by the delegate                           |
 
 ### Enum["all"]
 
@@ -357,3 +355,7 @@ function compare_string_descending {
 }
 Enum["sort"](list("foo","foobarbaz", "foobar"), compare_string_descending@). // list("foobarbaz","foobar","foo")
 ```
+---
+Copyright © 2015,2016 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_exec.md
+++ b/doc/lib_exec.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_exec
 
 This library is a powerful tool for unhardcoding program's behavior.
@@ -128,3 +126,7 @@ example:
     print my_expr.  // insert your main loop code here
   }
   ```
+---
+Copyright © 2015,2019,2020 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_exec.md
+++ b/doc/lib_exec.md
@@ -126,6 +126,7 @@ example:
     print my_expr.  // insert your main loop code here
   }
   ```
+
 ---
 Copyright © 2015,2019,2020 KSLib team
 

--- a/doc/lib_file_exists.md
+++ b/doc/lib_file_exists.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_file_exists.
 
 ``lib_file_exists.ks`` Is a means of checking for optional dependencies. Or checking whether a file exists before attempting to run it. 
@@ -15,3 +13,7 @@ returns:
   
 description:
   * This is intended to be used as a means to check if an attempt to run a file will succeed or fail before attempting do do so. Example uses are optional dependencies (adding options to a menu if relevant scripts are available) and checking if log files that only exist in certain events are present (can be used to pass instructions between cores or for saved variables in the event of a reboot). 
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_file_exists.md
+++ b/doc/lib_file_exists.md
@@ -13,6 +13,7 @@ returns:
   
 description:
   * This is intended to be used as a means to check if an attempt to run a file will succeed or fail before attempting do do so. Example uses are optional dependencies (adding options to a menu if relevant scripts are available) and checking if log files that only exist in certain events are present (can be used to pass instructions between cores or for saved variables in the event of a reboot). 
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_geodec.md
+++ b/doc/lib_geodec.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_geodec.
 
 `lib_geodec.ks` provides two functions to convert between geographic coordinates (latitude, longitude) and cartesian coordinates (x, y, z). The origin of the cartesian coordinates is at the center of the body, the positive x axis is directed to (0, 0) latitude and longitude. The positive z axis is directed to the south pole. As such the coordinate system is left handed.
@@ -29,3 +27,7 @@ returns:
 
 description:
   * Converts the cartesian coordinates into geocoordinates and altitude. The 3 items of the return list are to be interpreted as latitude, longitude and altitude, in that order.
+---
+Copyright © 2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_geodec.md
+++ b/doc/lib_geodec.md
@@ -27,6 +27,7 @@ returns:
 
 description:
   * Converts the cartesian coordinates into geocoordinates and altitude. The 3 items of the return list are to be interpreted as latitude, longitude and altitude, in that order.
+
 ---
 Copyright © 2019 KSLib team
 

--- a/doc/lib_gui_box.md
+++ b/doc/lib_gui_box.md
@@ -74,6 +74,7 @@ description:
   v    v
   chhhhc
   ```
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_gui_box.md
+++ b/doc/lib_gui_box.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_gui_box
 
 This library contains functions to draw boxes like this:
@@ -76,3 +74,7 @@ description:
   v    v
   chhhhc
   ```
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_input_string.md
+++ b/doc/lib_input_string.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_input_string.
 
 ``lib_input_string.ks`` provides a method of inputting custom strings while a script is running via an on-screen keyboard.
@@ -27,3 +25,7 @@ description:
     * pop-up windows requesting docking passwords.
     * Used in conjunction with `lib_exec` as a script selector.
     * As part of a larger set of scripts to provide script writing in the terminal window.
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_input_string.md
+++ b/doc/lib_input_string.md
@@ -25,6 +25,7 @@ description:
     * pop-up windows requesting docking passwords.
     * Used in conjunction with `lib_exec` as a script selector.
     * As part of a larger set of scripts to provide script writing in the terminal window.
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_input_terminal.md
+++ b/doc/lib_input_terminal.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_input_terminal.
 
 `lib_input_terminal` provides functions for getting user entered strings or numbers though terminal inputs.
@@ -79,3 +77,7 @@ description:
     Pressing backspace removes the last character from the current string until the string length is less than or equal to minLength
     Pressing delete sets the current string to an empty string.
   
+---
+Copyright © 2020 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_lazcalc.md
+++ b/doc/lib_lazcalc.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_LAZcalc.
 
 ``lib_LAZcalc.ks`` provides the user with a launch azimuth based on a desired target orbit altitude and
@@ -36,3 +34,7 @@ description:
   * To use:
     * First `SET `[stored data]` TO LAZcalc_init(`[target orbit]`,`[target inclination]`.`
     * Then loop `SET `[heading]` TO LAZcalc(`[stored data]`).` to continuously update your target heading.
+---
+Copyright © 2015,2017,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_lazcalc.md
+++ b/doc/lib_lazcalc.md
@@ -34,6 +34,7 @@ description:
   * To use:
     * First `SET `[stored data]` TO LAZcalc_init(`[target orbit]`,`[target inclination]`.`
     * Then loop `SET `[heading]` TO LAZcalc(`[stored data]`).` to continuously update your target heading.
+
 ---
 Copyright © 2015,2017,2019 KSLib team
 

--- a/doc/lib_list_dialog.md
+++ b/doc/lib_list_dialog.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_list_dailog
 
 This library helps when you want the user to choose a value from a long list.
@@ -41,3 +39,7 @@ description:
 
 description:
   This function is internal and should not be used outside of lib_list_dialog.
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_list_dialog.md
+++ b/doc/lib_list_dialog.md
@@ -39,6 +39,7 @@ description:
 
 description:
   This function is internal and should not be used outside of lib_list_dialog.
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_location_constants.md
+++ b/doc/lib_location_constants.md
@@ -70,3 +70,7 @@ If using the stock KSP solar system or the JNSQ system, the default locations ar
 * `location_constants:kerbin:runway_27_end`: alias for `runway_09_start` west (toward the mountains).
 * `location_constants:kerbin:runway_09_overrun`: The "lip" of the fully-upgraded KSC runway. Certain plane designs that can maintain level flight but cannot pitch up while landed should start pitching up when their wheels pass `runway_09_end`, since the lip will leave them airborne for a moment.
 * `location_constants:kerbin:runway_27_overrun`: The lip of the fully-upgraded KSC runway when headed toward the mountains. Mostly included for symmetry.
+---
+Copyright © 2020 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_location_constants.md
+++ b/doc/lib_location_constants.md
@@ -70,6 +70,7 @@ If using the stock KSP solar system or the JNSQ system, the default locations ar
 * `location_constants:kerbin:runway_27_end`: alias for `runway_09_start` west (toward the mountains).
 * `location_constants:kerbin:runway_09_overrun`: The "lip" of the fully-upgraded KSC runway. Certain plane designs that can maintain level flight but cannot pitch up while landed should start pitching up when their wheels pass `runway_09_end`, since the lip will leave them airborne for a moment.
 * `location_constants:kerbin:runway_27_overrun`: The lip of the fully-upgraded KSC runway when headed toward the mountains. Mostly included for symmetry.
+
 ---
 Copyright © 2020 KSLib team
 

--- a/doc/lib_menu.md
+++ b/doc/lib_menu.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_menu
 
 Use this library when you want to display a menu on the screen.
@@ -32,3 +30,7 @@ returns:
 
 description:
   * Identical to open_menu() but returns option index (an index in list_of_names list).
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_menu.md
+++ b/doc/lib_menu.md
@@ -30,6 +30,7 @@ returns:
 
 description:
   * Identical to open_menu() but returns option index (an index in list_of_names list).
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_navball.md
+++ b/doc/lib_navball.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_navball.
 
 ``lib_navball.ks`` provides useful routines to obtain information about
@@ -106,3 +104,7 @@ returns:
 description
   * Will convert several types into vectors.
     Intended for internal use by the functions of this library.
+---
+Copyright © 2015,2019,2020 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_navball.md
+++ b/doc/lib_navball.md
@@ -104,6 +104,7 @@ returns:
 description
   * Will convert several types into vectors.
     Intended for internal use by the functions of this library.
+
 ---
 Copyright © 2015,2019,2020 KSLib team
 

--- a/doc/lib_navigation.md
+++ b/doc/lib_navigation.md
@@ -170,6 +170,7 @@ returns:
 
 description:
   * Returns the azimuth (navball heading) required to launch to inclined orbit, taking into consideration current orbital velocity. If `auto_switch` is set, the function will check the ship's proximity with ascending and descending node to return a northward or southward azimuth, respectively.
+
 ---
 Copyright © 2019 KSLib team
 

--- a/doc/lib_navigation.md
+++ b/doc/lib_navigation.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_navigation
 
 `lib_navigation.ks` provides a plethora of useful functions to aid in writing navigational scripts, whether it's space navigation or surface navigation.
@@ -172,3 +170,7 @@ returns:
 
 description:
   * Returns the azimuth (navball heading) required to launch to inclined orbit, taking into consideration current orbital velocity. If `auto_switch` is set, the function will check the ship's proximity with ascending and descending node to return a northward or southward azimuth, respectively.
+---
+Copyright © 2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_num_to_formatted_str.md
+++ b/doc/lib_num_to_formatted_str.md
@@ -134,6 +134,7 @@ Format 5,6 will display only the 2 highest units for the passed in time they als
     time_formatting(31536000,6). will return the string " 001 Years   000 Days    "
     time_formatting(86400,6).    will return the string " 001 Days    00 Hours    "
     time_formatting(3600,6).     will return the string " 01 Hours    00 Minutes  "
+
 ---
 Copyright © 2015,2019,2020 KSLib team
 

--- a/doc/lib_num_to_formatted_str.md
+++ b/doc/lib_num_to_formatted_str.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_num_to_formatted_str.ks
 
 ``lib_num_to_formatted_str.ks`` provides several functions for changing numbers (scalers) into strings with specified formats
@@ -10,7 +8,7 @@ This function will return a string matching the format defined by the parameters
 
 
 | parameter        | type    | default | description                                                                                                                                                                     |
-|------------------|---------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | *num*            | Scalar  |         | The number to be formatted.                                                                                                                                                     |
 | *leadingLength*  | Scalar  |         | The minimum number of digits to the right of the decimal point.                                                                                                                 |
 | *trailingLength* | Scalar  |         | The number of digits to the right of the decimal point.                                                                                                                         |
@@ -57,7 +55,7 @@ This function will return a string matching the format defined by the parameters
 This function will return a string formatted to match standard SI notation with 4 significant digits.
 
 | parameter | type   | default | description                                                                                                                            |
-|-----------|--------|---------|----------------------------------------------------------------------------------------------------------------------------------------|
+| --------- | ------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | *num*     | Scalar |         | A number in the range 10^-24 to 10^24 (otherwise result will not be formatted correctly)                                               |
 | *unit*    | String |         | A unit for which the [SI prefixes](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes) will be appended ("m", "m/s", "g") |
 
@@ -83,7 +81,7 @@ This function will return a time string formatted according to the following rul
       * NOTE: you will need to keep the return the same format or else you will break other functions
 
 | parameter    | type    | default    | description                                                                     |
-|--------------|---------|------------|---------------------------------------------------------------------------------|
+| ------------ | ------- | ---------- | ------------------------------------------------------------------------------- |
 | *timeSec*    | Scalar  |            | The number to be formatted                                                      |
 | *formatType* | Scalar  |            | Selects type of format to be used, Range from 0 to 6                            |
 | *rounding*   | Scalar  | 0          | The rounding used for the seconds place, Range from 0 to 2                      |
@@ -136,3 +134,7 @@ Format 5,6 will display only the 2 highest units for the passed in time they als
     time_formatting(31536000,6). will return the string " 001 Years   000 Days    "
     time_formatting(86400,6).    will return the string " 001 Days    00 Hours    "
     time_formatting(3600,6).     will return the string " 01 Hours    00 Minutes  "
+---
+Copyright © 2015,2019,2020 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_num_to_str.md
+++ b/doc/lib_num_to_str.md
@@ -15,6 +15,7 @@ returns:
 description:
   * This returns a string containing the number fed to it with the decimal point always in the same position in the string.
     so it can be printed at the same location in the terminal without having to worry about it moving as the number becomes larger or smaller. 
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_num_to_str.md
+++ b/doc/lib_num_to_str.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_num_to_str
 
 ``lib_num_to_str.ks`` can be used to to format a number in a string of constant length for use in a display.
@@ -17,3 +15,7 @@ returns:
 description:
   * This returns a string containing the number fed to it with the decimal point always in the same position in the string.
     so it can be printed at the same location in the terminal without having to worry about it moving as the number becomes larger or smaller. 
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_number_dialog.md
+++ b/doc/lib_number_dialog.md
@@ -16,6 +16,7 @@ returns:
 
 description:
   * Open number dialog, return a number entered by  the user.
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_number_dialog.md
+++ b/doc/lib_number_dialog.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_number_dialog
 
 A dialog where the user can enter any number (including negative and fractional).
@@ -18,3 +16,7 @@ returns:
 
 description:
   * Open number dialog, return a number entered by  the user.
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_pid.md
+++ b/doc/lib_pid.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## Notice:
   lib_pid.ks has been superseded by the kOS inbuilt PIDloop() function.
   It is maintained for example purposes only, please see the kOS documentation for more.
@@ -51,3 +49,7 @@ description:
     a number back to you that you should immediately set the control
     that influences that property to.  An example showing it being
     used exists in the examples directory, to create a hovering rocket.
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_pid.md
+++ b/doc/lib_pid.md
@@ -49,6 +49,7 @@ description:
     a number back to you that you should immediately set the control
     that influences that property to.  An example showing it being
     used exists in the examples directory, to create a hovering rocket.
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_raw_user_input.md
+++ b/doc/lib_raw_user_input.md
@@ -17,6 +17,7 @@ returns:
 description:
   * Wait until user activates one of the action groups from ag_list,
     return the name of the activated action group.
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_raw_user_input.md
+++ b/doc/lib_raw_user_input.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_raw_user_input
 
 A low level library to do user input via action groups.
@@ -19,3 +17,7 @@ returns:
 description:
   * Wait until user activates one of the action groups from ag_list,
     return the name of the activated action group.
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_realchute.md
+++ b/doc/lib_realchute.md
@@ -17,6 +17,7 @@ returns:
 description:
   * This lets you use ``R_chutes("deploy chute").`` similar to how you would use ``Chutes on.``
     * Note: This will obey any rules that realchute sets for these chutes eg. they wont deploy on the way up if you have ticked ``Must go down to deploy``.
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_realchute.md
+++ b/doc/lib_realchute.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_realchute
 
 ``lib_realchute.ks`` can be used to activate chutes when using the RealChute mod.
@@ -19,3 +17,7 @@ returns:
 description:
   * This lets you use ``R_chutes("deploy chute").`` similar to how you would use ``Chutes on.``
     * Note: This will obey any rules that realchute sets for these chutes eg. they wont deploy on the way up if you have ticked ``Must go down to deploy``.
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_running_average_filter.md
+++ b/doc/lib_running_average_filter.md
@@ -1,4 +1,3 @@
-//This file is distributed under the terms of the MIT license, (c) the KSLib team
 //Authored by space_is_hard
 
 ## lib_running_average_filter
@@ -30,3 +29,7 @@ returns:
   
 description:
   * Outputs the running average of the latest input value and all of the historical values in the list
+---
+Copyright © 2015 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_running_average_filter.md
+++ b/doc/lib_running_average_filter.md
@@ -29,6 +29,7 @@ returns:
   
 description:
   * Outputs the running average of the latest input value and all of the historical values in the list
+
 ---
 Copyright © 2015 KSLib team
 

--- a/doc/lib_seven_seg.md
+++ b/doc/lib_seven_seg.md
@@ -7,6 +7,7 @@ args:
   
 description:
   * Prints a seven segment display on the terminal showing the input value at the location specified.
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_seven_seg.md
+++ b/doc/lib_seven_seg.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ### seven_seg
 
 args:
@@ -9,3 +7,7 @@ args:
   
 description:
   * Prints a seven segment display on the terminal showing the input value at the location specified.
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_str_to_num.md
+++ b/doc/lib_str_to_num.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## lib_str_to_num
 
 ``lib_str_to_num.ks`` can be used to convert a stringified number back into a
@@ -17,3 +15,7 @@ returns:
 
 description:
   * This is intended for cases where operating with various modules, tags, or other data necessitates pulling out numeric information from a string. In conjunction with [string manipulation](http://ksp-kos.github.io/KOS_DOC/structures/misc/string.html) tools, you can extract the numeric component, and then use this function to convert to the number itself.
+---
+Copyright © 2015,2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_str_to_num.md
+++ b/doc/lib_str_to_num.md
@@ -15,6 +15,7 @@ returns:
 
 description:
   * This is intended for cases where operating with various modules, tags, or other data necessitates pulling out numeric information from a string. In conjunction with [string manipulation](http://ksp-kos.github.io/KOS_DOC/structures/misc/string.html) tools, you can extract the numeric component, and then use this function to convert to the number itself.
+
 ---
 Copyright © 2015,2019 KSLib team
 

--- a/doc/lib_term.md
+++ b/doc/lib_term.md
@@ -90,3 +90,8 @@ description:
     GOTCHAS: Be aware that on the terminal screen, positive Y is DOWN,
     not UP, which may yield confusing results about which way is
     positive degrees of the arc, if you're not taking it into account.
+
+---
+Copyright © 2015,2020 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/doc/lib_term.md
+++ b/doc/lib_term.md
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_term.md 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 // Original starting work by Github user: Dunbaratu
 
 ## lib_term

--- a/examples/example_lib_exec.ks
+++ b/examples/example_lib_exec.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_exec.ks 
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 
 run lib_exec.
 

--- a/examples/example_lib_geodec.ks
+++ b/examples/example_lib_geodec.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_geodec.ks 
+// Copyright © 2019 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL off.
 
 runPath("lib_geodec.ks").

--- a/examples/example_lib_gui_box.ks
+++ b/examples/example_lib_gui_box.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_gui_box.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
 run lib_gui_box.
 

--- a/examples/example_lib_input_string.ks
+++ b/examples/example_lib_input_string.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_input_string.ks 
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 
 // This is intended to be run as a boot script.
 

--- a/examples/example_lib_input_terminal_complex.ks
+++ b/examples/example_lib_input_terminal_complex.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_input_terminal_complex.ks 
+// Copyright © 2020 KSLib team 
+// Lic. MIT
 
 @LAZYGLOBAL OFF.
 

--- a/examples/example_lib_input_terminal_simple.ks
+++ b/examples/example_lib_input_terminal_simple.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_input_terminal_simple.ks 
+// Copyright © 2020 KSLib team 
+// Lic. MIT
 
 @LAZYGLOBAL OFF.
 

--- a/examples/example_lib_lazcalc.ks
+++ b/examples/example_lib_lazcalc.ks
@@ -1,6 +1,6 @@
-//LIB_LAZcalc.ks testing example
-//This file is distributed under the terms of the MIT license, (c) the KSLib team
-
+// example_lib_lazcalc.ks is a LIB_LAZcalc.ks testing example
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 SWITCH TO 0.
 RUN lib_lazcalc.ks.
 CLEARSCREEN.

--- a/examples/example_lib_list_dialog.ks
+++ b/examples/example_lib_list_dialog.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_list_dialog.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
 run lib_list_dialog.
 set numbers to list("0", "1", "2", "3", "4", "5", "6", "7", "8", "9").

--- a/examples/example_lib_location_constants.ks
+++ b/examples/example_lib_location_constants.ks
@@ -1,3 +1,7 @@
+// example_lib_location_constants.ks 
+// Copyright © 2020 KSLib team 
+// Lic. MIT
+
 @LAZYGLOBAL off.
 
 runpath("lib_location_constants.ks").

--- a/examples/example_lib_menu.ks
+++ b/examples/example_lib_menu.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_menu.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
 run lib_menu.
 

--- a/examples/example_lib_navball.ks
+++ b/examples/example_lib_navball.ks
@@ -1,5 +1,6 @@
-// Testing the lib_navball functions.
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_navball.ks tests the lib_navball functions.
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 
 run lib_navball.
 

--- a/examples/example_lib_navigation.ks
+++ b/examples/example_lib_navigation.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_navigation.ks 
+// Copyright © 2019 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL OFF.
 
 runPath("lib_navigation.ks").

--- a/examples/example_lib_num_to_formatted_str.ks
+++ b/examples/example_lib_num_to_formatted_str.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_num_to_formatted_str.ks 
+// Copyright © 2018,2019 KSLib team 
+// Lic. MIT
 
 RUN lib_num_to_formated_str.
 CLEARSCREEN.

--- a/examples/example_lib_num_to_str.ks
+++ b/examples/example_lib_num_to_str.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_num_to_str.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
 run lib_num_to_str.
 local num is 0.

--- a/examples/example_lib_number_dialog.ks
+++ b/examples/example_lib_number_dialog.ks
@@ -1,3 +1,7 @@
+// example_lib_number_dialog.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
+
 run lib_number_dialog.
 
 set number to open_number_dialog("Apoapsis:",100000).

--- a/examples/example_lib_pid.ks
+++ b/examples/example_lib_pid.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_pid.ks 
+// Copyright © 2015,2016 KSLib team 
+// Lic. MIT
 clearscreen.
 SAS on.
 set seekAlt to 25.

--- a/examples/example_lib_raw_user_input.ks
+++ b/examples/example_lib_raw_user_input.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_raw_user_input.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 run lib_raw_user_input.
 local quit is false.
 until quit

--- a/examples/example_lib_running_average_filter.ks
+++ b/examples/example_lib_running_average_filter.ks
@@ -1,6 +1,6 @@
-//example_lib_running_average_filter
-//This file is distributed under the terms of the MIT license, (c) the KSLib team
-//Authored by space_is_hard
+// example_lib_running_average_filter.ks 
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT//Authored by space_is_hard
 
 SWITCH TO 0.
 RUN lib_running_average_filter.

--- a/examples/example_lib_seven_seg.ks
+++ b/examples/example_lib_seven_seg.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_seven_seg.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
 run lib_seven_seg.
 

--- a/examples/example_lib_str_to_num.ks
+++ b/examples/example_lib_str_to_num.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_str_to_num.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
 run lib_str_to_num.
 

--- a/examples/example_lib_term_clock.ks
+++ b/examples/example_lib_term_clock.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_lib_term_clock.ks 
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 // Original starting work by Github user: Dunbaratu
 
 // Example that uses some of the lib_term line drawing

--- a/examples/example_testsasmode.ks
+++ b/examples/example_testsasmode.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// example_testsasmode.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
 clearscreen.
 set oldsas to sas.

--- a/games/Game_Of_Ur/Game_of_Ur.ks
+++ b/games/Game_Of_Ur/Game_of_Ur.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// Game_of_Ur.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 // Originally developed by nuggreat
 
 SET TERMINAL:WIDTH TO 70.

--- a/games/Game_Of_Ur/README.md
+++ b/games/Game_Of_Ur/README.md
@@ -39,3 +39,8 @@ The starting area is numbered -5.
 The ending area is numbered 10.
 
 Several examples of various rules as well as a copy of the rules can also be found in the help menu with in the game itself.
+
+---
+Copyright © 2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/games/README.md
+++ b/games/README.md
@@ -15,3 +15,7 @@ A short summary of each game can be found [HERE](https://github.com/KSP-KOS/KSLi
 If you wish to contribute a game it must be something that is in the public domain.
 
 All contributed games fall under the same licensing as all other code in this repository as out lined [HERE](https://github.com/KSP-KOS/KSLib/blob/master/README.md#licensing)
+---
+Copyright © 2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/games/README.md
+++ b/games/README.md
@@ -15,6 +15,7 @@ A short summary of each game can be found [HERE](https://github.com/KSP-KOS/KSLi
 If you wish to contribute a game it must be something that is in the public domain.
 
 All contributed games fall under the same licensing as all other code in this repository as out lined [HERE](https://github.com/KSP-KOS/KSLib/blob/master/README.md#licensing)
+
 ---
 Copyright © 2019 KSLib team
 

--- a/games/SUMMARY.md
+++ b/games/SUMMARY.md
@@ -9,3 +9,7 @@ This is a summary of all games found in KSlib
   To allow for a single person play, several AI are offered.
 	
 	[game](https://github.com/KSP-KOS/KSLib/blob/master/games/Game_Of_Ur/Game_of_Ur.ks)
+---
+Copyright © 2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/games/SUMMARY.md
+++ b/games/SUMMARY.md
@@ -9,6 +9,7 @@ This is a summary of all games found in KSlib
   To allow for a single person play, several AI are offered.
 	
 	[game](https://github.com/KSP-KOS/KSLib/blob/master/games/Game_Of_Ur/Game_of_Ur.ks)
+
 ---
 Copyright © 2019 KSLib team
 

--- a/library/lib_circle_nav.ks
+++ b/library/lib_circle_nav.ks
@@ -1,6 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
-
+// lib_circle_nav.ks provides a set of functions that use Great Circle equations.
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL OFF.
 
 //use to find the initial bearing for the shortest path around a sphere from...

--- a/library/lib_enum.ks
+++ b/library/lib_enum.ks
@@ -1,5 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib
-// team
+// lib_enum.ks provides a set of functions for manipulating lists, queues, and stacks using the new delegates syntax introduced in kOS version 0.19.0.
+// Copyright © 2015,2016 KSLib team 
+// Lic. MIT
 
 {global Enum is lex(
 "version", "0.1.1",

--- a/library/lib_exec.ks
+++ b/library/lib_exec.ks
@@ -1,4 +1,7 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_exec.ks - executes a command from its string representation.
+// Copyright © 2015,2019,2020 KSLib team 
+// Lic. MIT
+
 // Originally developed by abenkovskii
 
 // The mess below declares a function execute that executes a command from it's string representation.

--- a/library/lib_file_exists.ks
+++ b/library/lib_file_exists.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_file_exists.ks is a means of checking for optional dependencies, or checking whether a file exists before attempting to run it.
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
 @LAZYGLOBAL off.
 

--- a/library/lib_geodec.ks
+++ b/library/lib_geodec.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_geodec.ks provides two functions to convert between geographic coordinates (latitude, longitude) and cartesian coordinates (x, y, z).
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL off.
 
 function geo2dec {

--- a/library/lib_gui_box.ks
+++ b/library/lib_gui_box.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_gui_box.ks contains functions to draw boxes in the terminal.
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 // This file is based on lib_window.ks from akrOS by akrasuski1.
 
 function draw_custom_gui_box {

--- a/library/lib_input_string.ks
+++ b/library/lib_input_string.ks
@@ -1,5 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
+// lib_input_string.ks provides a method of inputting custom strings while a script is running via an on-screen keyboard.
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL off.
 
 function input_string

--- a/library/lib_input_terminal.ks
+++ b/library/lib_input_terminal.ks
@@ -1,5 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
+// lib_input_terminal.ks provides functions for getting user entered strings or numbers though terminal inputs.
+// Copyright © 2020 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL OFF.
 
 LOCAL termIn IS TERMINAL:INPUT.     

--- a/library/lib_lazcalc.ks
+++ b/library/lib_lazcalc.ks
@@ -1,6 +1,7 @@
-//This file is distributed under the terms of the MIT license, (c) the KSLib team
-//=====LAUNCH AZIMUTH CALCULATOR=====
-//~~LIB_LAZcalc.ks~~
+// lib_lazcalc.ks - provides the user with a launch azimuth based on a desired target orbit altitude and inclination and can continued to be used throughout ascent to update the heading. It bases this calculation on the vessel's launch and current geoposition.
+// Copyright © 2015,2017 KSLib team 
+// Lic. MIT
+
 //~~Version 2.2~~
 //~~Created by space-is-hard~~
 //~~Updated by TDW89~~

--- a/library/lib_list_dialog.ks
+++ b/library/lib_list_dialog.ks
@@ -1,5 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
+// lib_list_dialog.ks helps when you want the user to choose a value from a long list.
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL OFF.
 
 run lib_menu.

--- a/library/lib_location_constants.ks
+++ b/library/lib_location_constants.ks
@@ -1,3 +1,6 @@
+// lib_location_constants.ks provides geolocations for places that would be relatively easy to locate for players flying manually (i.e., without the use of scripting mods such as kOS).
+// Copyright © 2020 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL off.
 
 if not (defined location_constants) {

--- a/library/lib_menu.ks
+++ b/library/lib_menu.ks
@@ -1,7 +1,6 @@
-// This script shows a menu on the terminal allowing user to
-// select one of the options and return it to calling script.
-
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_menu.ks - select one of the options and return it to calling script.
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
 @lazyglobal off.
 

--- a/library/lib_navball.ks
+++ b/library/lib_navball.ks
@@ -1,6 +1,6 @@
-// A library of functions to calculate navball-based directions:
-
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_navball.ks - A library of functions to calculate navball-based directions.
+// Copyright © 2015,2017,2019 KSLib team 
+// Lic. MIT
 
 @lazyglobal off.
 

--- a/library/lib_navigation.ks
+++ b/library/lib_navigation.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_navigation.ks provides a plethora of useful functions to aid in writing navigational scripts, whether it's space navigation or surface navigation.
+// Copyright © 2019,2020 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL OFF.
 
 // Same as orbital prograde vector for ves

--- a/library/lib_num_to_formatted_str.ks
+++ b/library/lib_num_to_formatted_str.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_num_to_formatted_str.ks provides several functions for changing numbers (scalers) into strings with specified formats
+// Copyright © 2018,2019,2020 KSLib team 
+// Lic. MIT
 
 @LAZYGLOBAL OFF.
 

--- a/library/lib_num_to_str.ks
+++ b/library/lib_num_to_str.ks
@@ -1,5 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
+// lib_num_to_str.ks can be used to to format a number in a string of constant length for use in a display.
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL off.
 
 function num_to_str {

--- a/library/lib_number_dialog.ks
+++ b/library/lib_number_dialog.ks
@@ -1,5 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
+// lib_number_dialog.ks provides a dialog where the user can enter any number (including negative and fractional).
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 run lib_gui_box.
 
 function open_number_dialog

--- a/library/lib_pid.ks
+++ b/library/lib_pid.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_pid.ks provides routines to implement a simple generic PID controller.
+// Copyright © 2015,2016,2019 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL off.
 
 HUDTEXT("lib_pid.ks has been superseded by the kOS inbuilt PIDloop() function.", 10, 2, 30, RED, FALSE).

--- a/library/lib_raw_user_input.ks
+++ b/library/lib_raw_user_input.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_raw_user_input.ks provides a low level library to do user input via action groups. I believe it supports AGX to.
+// Copyright © 2015,2020 KSLib team 
+// Lic. MIT
 // Originally developed by abenkovskii
 @LAZYGLOBAL OFF.
 

--- a/library/lib_realchute.ks
+++ b/library/lib_realchute.ks
@@ -1,6 +1,7 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_realchute.ks - adds support for RealChute 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
-// adds support for RealChute 
 @LAZYGLOBAL OFF.
 declare function R_chutes {
  parameter event.

--- a/library/lib_running_average_filter.ks
+++ b/library/lib_running_average_filter.ks
@@ -1,6 +1,6 @@
-//Running Average Filter
-//lib_running_average_filter.ks
-//This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_running_average_filter.ks provides a function that will filter out noise from a dataset by storing a number of previous values of that dataset and outputting the average (mean) of those values.
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 //Authored by space_is_hard
 
 //These functions will set up and implement a running

--- a/library/lib_seven_seg.ks
+++ b/library/lib_seven_seg.ks
@@ -1,5 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
+// lib_seven_seg.ks prints a seven segment display on the terminal showing the input value at the location specified.
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 function seven_seg {
  parameter
   num,

--- a/library/lib_str_to_num.ks
+++ b/library/lib_str_to_num.ks
@@ -1,5 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
+// lib_str_to_num.ks can be used to convert a stringified number back into a legitimate number for use in computation.
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 @LAZYGLOBAL off.
 
 local num_lex   is lexicon().

--- a/library/lib_term.ks
+++ b/library/lib_term.ks
@@ -1,8 +1,8 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_term.ks - terminal manipulations
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 // Original starting work by Github user: Dunbaratu
 
-// terminal manipulations
-//
 @lazyglobal off.
 
 // -----------

--- a/library_ksm/README.md
+++ b/library_ksm/README.md
@@ -2,3 +2,8 @@
 This folder **must not** contain files people can compile locally from .ks files of your library. It is only for files made or modified by external programs to allow stuff that isn't possible in Kerboscript but is possible in opcode. It is **highly recommended** to minimize the amount of code placed in here because:
 * Backwards compatibility for .ksm files is not guarantied (e.g. some significant parser changes might break all old .ksm files).
 * It is a lot more difficult to modify and improve .ksm files when compared to .ks scripts.
+
+---
+Copyright © 2019 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/specs/lib_enum_spec.ks
+++ b/specs/lib_enum_spec.ks
@@ -1,5 +1,6 @@
-// This file is distributed under the terms of the MIT license,
-// (c) the KSLib team
+// lib_enum_spec.ks 
+// Copyright © 2015,2016 KSLib team 
+// Lic. MIT
 // Note: This requires KSpec - see https://github.com/gisikw/kspec
 
 RUN lib_enum.

--- a/stripper/pack.sh
+++ b/stripper/pack.sh
@@ -1,4 +1,8 @@
-# This file is distributed under the terms of the MIT license, (c) the KSLib team
+#!/bin/sh
+
+# pack.sh 
+# Copyright © 2015 KSLib team 
+# Lic. MIT
 
 # The purpose of this file is to decrease size of .ks files for the final flight. However, please upload 
 # UNPACKED versions of programs to KSLib.

--- a/unit_tests/lib_exec/README.md
+++ b/unit_tests/lib_exec/README.md
@@ -21,6 +21,7 @@ to the screen. If something is broken you'll get an exception.
 
 ### bonus:
 Check out lib_testing. It might help you write your own unit tests.
+
 ---
 Copyright © 2015,2020 KSLib team
 

--- a/unit_tests/lib_exec/README.md
+++ b/unit_tests/lib_exec/README.md
@@ -1,5 +1,3 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
-
 ## unit_tests/lib_exec
 
 A unit test for all edge cases of lib_exec I know.
@@ -23,3 +21,7 @@ to the screen. If something is broken you'll get an exception.
 
 ### bonus:
 Check out lib_testing. It might help you write your own unit tests.
+---
+Copyright © 2015,2020 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/unit_tests/lib_exec/lib_testing.ks
+++ b/unit_tests/lib_exec/lib_testing.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// lib_testing.ks 
+// Copyright © 2015 KSLib team 
+// Lic. MIT
 
 @lazyglobal off.
 

--- a/unit_tests/lib_exec/test_lib_exec_0.ks
+++ b/unit_tests/lib_exec/test_lib_exec_0.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// test_lib_exec_0.ks 
+// Copyright © 2015,2019,2020 KSLib team 
+// Lic. MIT
 
 run lib_exec.
 run lib_testing.

--- a/unit_tests/lib_exec/test_lib_exec_1.internal_1.ks
+++ b/unit_tests/lib_exec/test_lib_exec_1.internal_1.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// test_lib_exec_1.internal_1.ks 
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 
 run lib_exec.
 run lib_testing.

--- a/unit_tests/lib_exec/test_lib_exec_1.internal_2.ks
+++ b/unit_tests/lib_exec/test_lib_exec_1.internal_2.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// test_lib_exec_1.internal_2.ks 
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 
 run lib_exec.
 run lib_testing.

--- a/unit_tests/lib_exec/test_lib_exec_1.ks
+++ b/unit_tests/lib_exec/test_lib_exec_1.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// test_lib_exec_1.ks 
+// Copyright © 2015,2019 KSLib team 
+// Lic. MIT
 
 run lib_testing.
 

--- a/unit_tests/lib_exec/test_lib_exec_2.internal_1.ks
+++ b/unit_tests/lib_exec/test_lib_exec_2.internal_1.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// test_lib_exec_2.internal_1.ks 
+// Copyright © 2015,2020 KSLib team 
+// Lic. MIT
 
 run lib_exec.
 run lib_testing.

--- a/unit_tests/lib_exec/test_lib_exec_2.ks
+++ b/unit_tests/lib_exec/test_lib_exec_2.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// test_lib_exec_2.ks 
+// Copyright © 2015,2020 KSLib team 
+// Lic. MIT
 
 run lib_exec.
 run lib_testing.

--- a/unit_tests/lib_exec/test_lib_exec_3.ks
+++ b/unit_tests/lib_exec/test_lib_exec_3.ks
@@ -1,4 +1,6 @@
-// This file is distributed under the terms of the MIT license, (c) the KSLib team
+// test_lib_exec_3.ks 
+// Copyright © 2020 KSLib team 
+// Lic. MIT
 
 run lib_exec.
 run lib_testing.


### PR DESCRIPTION
NOTE: This touched every file except for the single .png and the LICENSE.  It only changes to comments at the very top or very bottom of each file.  It's the nature of this kind of change, but the review should and merge should be straightforward.

Changes:
Shell Script: pack.sh: Added shebang, chmod +x, then...

All source: a line with the filename plus a one-line description when conveniently available; then a copyright notice line with the years there have been commits for that specific file; then a short reference to the MIT License's SPDX ID.

All doc: remove any licensing or copyright at the head of the file; then add a horizontal rule to create a footer containing a copyright line with appropriate years; then in a separate paragraph notice that the document and any code samples it contains are MIT Licensed.