### PR TITLE
Hyperbolic trigonometry

### DIFF
--- a/doc/lib_hyperbolic_trigonometry.md
+++ b/doc/lib_hyperbolic_trigonometry.md
@@ -1,0 +1,77 @@
+## lib_hyperbolic_trigonometry
+
+A library which provides the usual hyperbolic functions and their inverses.  
+Sources:
+  * [Hyperbolic_functions#Exponential_definitions](https://en.wikipedia.org/wiki/Hyperbolic_functions#Exponential_definitions)
+  * [Hyperbolic_functions#Inverse_functions_as_logarithms](https://en.wikipedia.org/wiki/Hyperbolic_functions#Inverse_functions_as_logarithms)
+
+### cosh
+
+args:
+  * x - angle in degrees
+
+returns:
+  * number - hyperbolic cosine of x
+
+description:
+  * This function calculates the hyperbolic cosine of x
+
+### sinh
+
+args:
+  * x - angle in degrees
+
+returns:
+  * number - hyperbolic sine of x
+
+description:
+  * This function calculates the hyperbolic sine of x
+
+### tanh
+
+args:
+  * x - angle in degrees
+
+returns:
+  * number - hyperbolic tangent of x
+
+description:
+  * This function calculates the hyperbolic tangent of x
+
+### arccosh
+
+args:
+  * n - number, n >= 1
+
+returns:
+  * number - angle in degrees
+
+description:
+  * This function calculates the inverse hyperbolic cosine of n
+
+### arcsinh
+
+args:
+  * n - number
+
+returns:
+  * number - angle in degrees
+
+description:
+  * This function calculates the inverse hyperbolic sine of n
+
+### arctanh
+
+args:
+  * n - number, -1 > n > 1
+
+returns:
+  * number - angle in degrees
+
+description:
+  * This function calculates the inverse hyperbolic tangent of n
+
+---
+Copyright © 2015,2021 KSLib team
+
+This work and any code samples presented herein are licensed under the [MIT license](../LICENSE).

--- a/library/lib_hyperbolic_trigonometry.ks
+++ b/library/lib_hyperbolic_trigonometry.ks
@@ -1,0 +1,42 @@
+// lib_hyperbolic_trigonometry.ks provides the usual hyperbolic functions and their inverses.
+// Copyright © 2015 KSLib team 
+// Lic. MIT
+
+function cosh {
+  parameter x.
+  
+  local toRadian to x * constant:degToRad.
+  return (constant:e^toRadian + constant:e^(-toRadian)) / 2.
+}
+
+function sinh {
+  parameter x.
+  
+  local toRadian to x * constant:degToRad.
+  return (constant:e^toRadian - constant:e^(-toRadian)) / 2.
+}
+
+function tanh {
+  parameter x.
+  
+  local toRadian to x * constant:degToRad.
+  return (1 - constant:e^(-2 * toRadian)) / (1 + constant:e^(-2 * toRadian)).
+}
+
+function arccosh {
+  parameter n.
+  
+  return ln(n + sqrt(n + 1) * sqrt(n - 1)) * constant:radToDeg.
+}
+
+function arcsinh {
+  parameter n.
+  
+  return ln(n + sqrt(1 + n^2)) * constant:radToDeg.
+}
+
+function arctanh {
+  parameter n.
+  
+  return (ln((1 + n) / (1 - n)) / 2) * constant:radToDeg.
+}


### PR DESCRIPTION
Cos, sin, tan, arccos, arcsin and arctan are in KOS but not their hyperbolic equivalents, so here's some code for them.