### PR TITLE
fixed bug in roll_for() function in lib_navball.ks

### DIFF
--- a/library/lib_navball.ks
+++ b/library/lib_navball.ks
@@ -58,10 +58,10 @@ function roll_for {
 	}
   }
 
-  local trig_x is vdot(pointing:topvector,ves:up:vector).
-  if abs(trig_x) < 0.0035 {//this is the dead zone for roll when within 0.2 degrees of vertical
+  if vang(pointing:topvector,ves:up:vector) < 0.2 {//this is the dead zone for roll when within 0.2 degrees of vertical
     return 0.
   } else {
+    local trig_x is vdot(pointing:topvector,ves:up:vector).
     local vec_y is vcrs(ves:up:vector,ves:facing:forevector).
     local trig_y is vdot(pointing:topvector,vec_y).
     return arctan2(trig_y,trig_x).

--- a/library/lib_navball.ks
+++ b/library/lib_navball.ks
@@ -54,8 +54,8 @@ function roll_for {
     } else if thing:istype("direction") {
       set pointing to thing.
     } else {
-      print "type: " + thing:typename + " is not reconized by roll_for".
-	}
+      print "type: " + thing:typename + " is not recognized by roll_for".
+    }
   }
 
   if vang(pointing:topvector,ves:up:vector) < 0.2 {//this is the dead zone for roll when within 0.2 degrees of vertical


### PR DESCRIPTION
fixes issue #147
Fixes bug where roll would be incorrectly reported as zero when not within 0.2 degrees of vertical due to a mistake in the vector math.